### PR TITLE
feat: Dhi-style comptime counter config with bounds validation

### DIFF
--- a/app/counter.zig
+++ b/app/counter.zig
@@ -1,5 +1,7 @@
+const std = @import("std");
 const mer = @import("mer");
 const h = mer.h;
+const cfg = mer.counter_config.config;
 
 pub const meta: mer.Meta = .{
     .title = "Counter",
@@ -28,22 +30,42 @@ fn page() h.Node {
             h.h1(.{}, "Counter"),
             h.p(.{ .class = "sub", .style = "margin-top:8px" }, "State lives in Zig/WASM. JS just applies patches."),
         }),
-        h.div(.{ .class = "count", .id = "count-value" }, "0"),
+        h.div(.{ .class = "count", .id = "count-value" }, comptimeIntStr(cfg.initial)),
+        h.div(.{ .class = "bounds" }, .{
+            h.span(.{ .class = "bound" }, .{h.raw("min: <strong>" ++ comptimeIntStr(cfg.min) ++ "</strong>")}),
+            h.span(.{ .class = "bound-sep" }, .{h.raw("&middot;")}),
+            h.span(.{ .class = "bound" }, .{h.raw("step: <strong>" ++ comptimeIntStr(cfg.step) ++ "</strong>")}),
+            h.span(.{ .class = "bound-sep" }, .{h.raw("&middot;")}),
+            h.span(.{ .class = "bound" }, .{h.raw("max: <strong>" ++ comptimeIntStr(cfg.max) ++ "</strong>")}),
+        }),
         h.div(.{ .class = "buttons" }, .{
             h.button(.{ .id = "btn-dec", .class = "btn", .@"type" = "button" }, .{h.raw("&minus;")}),
             h.button(.{ .id = "btn-reset", .class = "btn btn-reset", .@"type" = "button" }, "reset"),
             h.button(.{ .id = "btn-inc", .class = "btn btn-inc", .@"type" = "button" }, "+"),
         }),
         h.span(.{ .class = "badge" }, "wasm32-freestanding"),
+        h.div(.{ .class = "config-note" }, .{
+            h.raw("Bounds enforced at <strong>comptime</strong> via "),
+            h.code(.{}, "counter_config.zig"),
+            h.raw(" &mdash; change the values and the compiler validates them."),
+        }),
         h.a(.{ .href = "/", .class = "back" }, .{h.raw("&larr; home")}),
         h.script(.{}, counter_js),
     });
 }
 
+fn comptimeIntStr(comptime val: i32) []const u8 {
+    return std.fmt.comptimePrint("{d}", .{val});
+}
+
 const counter_js =
     \\(async function(){
     \\  const display = document.getElementById('count-value');
-    \\  let count = 0;
+    ++ std.fmt.comptimePrint(
+    \\  const MIN={d}, MAX={d}, STEP={d}, INIT={d};
+, .{ cfg.min, cfg.max, cfg.step, cfg.initial }) ++
+    \\  let count = INIT;
+    \\  function clamp(v){ return Math.max(MIN, Math.min(MAX, v)); }
     \\  function sync(){ display.textContent = count; }
     \\  try {
     \\    const {instance} = await WebAssembly.instantiateStreaming(fetch('/counter.wasm'),{});
@@ -53,9 +75,9 @@ const counter_js =
     \\    document.getElementById('btn-reset').onclick = ()=>{ w.reset(); display.textContent = w.get_count(); };
     \\    display.textContent = w.get_count();
     \\  } catch(e) {
-    \\    document.getElementById('btn-inc').onclick = ()=>{ count++; sync(); };
-    \\    document.getElementById('btn-dec').onclick = ()=>{ count--; sync(); };
-    \\    document.getElementById('btn-reset').onclick = ()=>{ count=0; sync(); };
+    \\    document.getElementById('btn-inc').onclick = ()=>{ count = clamp(count + STEP); sync(); };
+    \\    document.getElementById('btn-dec').onclick = ()=>{ count = clamp(count - STEP); sync(); };
+    \\    document.getElementById('btn-reset').onclick = ()=>{ count = INIT; sync(); };
     \\  }
     \\})();
 ;
@@ -81,6 +103,12 @@ const page_css =
     \\  color:var(--text); letter-spacing:-0.04em;
     \\  min-width:3ch; text-align:center;
     \\}
+    \\.bounds {
+    \\  display:flex; gap:12px; align-items:center;
+    \\  font-size:12px; color:var(--muted);
+    \\}
+    \\.bounds strong { color:var(--text); font-weight:600; }
+    \\.bound-sep { color:var(--border); }
     \\.buttons { display:flex; gap:12px; align-items:center; }
     \\.btn {
     \\  width:52px; height:52px; border-radius:8px;
@@ -104,5 +132,14 @@ const page_css =
     \\  font-size:11px; color:var(--muted); background:var(--bg2);
     \\  border:1px solid var(--border); border-radius:100px;
     \\  padding:4px 12px; letter-spacing:0.04em;
+    \\}
+    \\.config-note {
+    \\  font-size:12px; color:var(--muted); max-width:360px; line-height:1.6;
+    \\}
+    \\.config-note strong { color:var(--text); }
+    \\.config-note code {
+    \\  font-family:'SF Mono','Fira Code',monospace;
+    \\  font-size:11px; background:var(--bg3);
+    \\  border-radius:4px; padding:1px 6px;
     \\}
 ;

--- a/build.zig
+++ b/build.zig
@@ -15,6 +15,9 @@ pub fn build(b: *std.Build) void {
     });
     mer_mod.addImport("dhi_model", dhi_model_mod);
     mer_mod.addImport("dhi_validator", dhi_validator_mod);
+    mer_mod.addImport("counter_config", b.addModule("counter_config", .{
+        .root_source_file = b.path("wasm/counter_config.zig"),
+    }));
 
     // ── Main module ─────────────────────────────────────────────────────────
     const main_mod = b.createModule(.{

--- a/src/mer.zig
+++ b/src/mer.zig
@@ -79,3 +79,6 @@ pub fn render(allocator: std.mem.Allocator, node: h.Node) Response {
 ///   });
 ///   const user = try User.parse(.{ .name = "Alice", .email = "a@b.com" });
 pub const dhi = @import("dhi.zig");
+
+// --- Counter config (shared with WASM module) --------------------------------
+pub const counter_config = @import("counter_config");

--- a/wasm/counter.zig
+++ b/wasm/counter.zig
@@ -1,14 +1,25 @@
 // counter.zig — compiled to wasm32-freestanding.
 // Zig owns all counter state; JS is a dumb shim that calls these exports.
+// Bounds validated at comptime via counter_config.zig (Dhi-style constraints).
 
-var count: i32 = 0;
+const cfg = @import("counter_config.zig").config;
+
+var count: i32 = cfg.initial;
 
 export fn increment() void {
-    count += 1;
+    if (count <= cfg.max - cfg.step) {
+        count += cfg.step;
+    } else {
+        count = cfg.max;
+    }
 }
 
 export fn decrement() void {
-    count -= 1;
+    if (count >= cfg.min + cfg.step) {
+        count -= cfg.step;
+    } else {
+        count = cfg.min;
+    }
 }
 
 export fn get_count() i32 {
@@ -16,5 +27,17 @@ export fn get_count() i32 {
 }
 
 export fn reset() void {
-    count = 0;
+    count = cfg.initial;
+}
+
+export fn get_min() i32 {
+    return cfg.min;
+}
+
+export fn get_max() i32 {
+    return cfg.max;
+}
+
+export fn get_step() i32 {
+    return cfg.step;
 }

--- a/wasm/counter_config.zig
+++ b/wasm/counter_config.zig
@@ -1,0 +1,37 @@
+// counter_config.zig — Comptime-validated counter configuration.
+// Shared between app/counter.zig (page) and wasm/counter.zig (WASM module).
+// Dhi-style constraints enforced at compile time.
+
+/// Counter bounds and behavior, validated at comptime.
+pub const CounterConfig = struct {
+    min: i32,
+    max: i32,
+    step: i32,
+    initial: i32,
+
+    /// Validate config at comptime with Dhi-style constraint checks.
+    pub fn validate(comptime self: CounterConfig) CounterConfig {
+        if (self.min >= self.max)
+            @compileError("CounterConfig: min must be less than max");
+        if (self.step <= 0)
+            @compileError("CounterConfig: step must be positive (gt 0)");
+        if (self.step > 100)
+            @compileError("CounterConfig: step must be <= 100");
+        if (self.min < -10_000)
+            @compileError("CounterConfig: min must be >= -10000");
+        if (self.max > 10_000)
+            @compileError("CounterConfig: max must be <= 10000");
+        if (self.initial < self.min or self.initial > self.max)
+            @compileError("CounterConfig: initial must be within [min, max]");
+        return self;
+    }
+};
+
+/// The active counter configuration — change these values and the compiler
+/// will validate them. Both the page UI and WASM module use this.
+pub const config = (CounterConfig{
+    .min = -100,
+    .max = 100,
+    .step = 1,
+    .initial = 0,
+}).validate();


### PR DESCRIPTION
Closes #10, closes #11, closes #12

Adds a shared `wasm/counter_config.zig` with Dhi-style comptime-validated counter configuration.

**What's new:**
- `CounterConfig` struct with `.validate()` — `@compileError`s on invalid bounds/step
- Config shared between `app/counter.zig` (page) and `wasm/counter.zig` (WASM module)
- WASM counter enforces min/max/step bounds (no overflow past limits)
- Page UI displays bounds: `min: -100 · step: 1 · max: 100`
- JS fallback also uses bounds via `comptimePrint` injection
- Explanatory note on the page about comptime validation

**Comptime safety:**
Change `min = 200, max = 100` → compiler errors with `CounterConfig: min must be less than max`