### PR TITLE
feat: enforce Meta SEO on all pages + migrate dashboard/users/weather to layout

### DIFF
--- a/app/dashboard.zig
+++ b/app/dashboard.zig
@@ -1,128 +1,77 @@
 const std = @import("std");
 const mer = @import("mer");
 
+pub const meta: mer.Meta = .{
+    .title = "Dashboard",
+    .description = "SSR dashboard with live API polling. Server-side rendered at request time, client polls /api/time every second.",
+    .og_title = "Dashboard \u{2014} merjs",
+    .og_description = "SSR + live API polling. Rendered by Zig, zero Node.js.",
+    .twitter_card = "summary",
+    .twitter_title = "Dashboard \u{2014} merjs",
+    .twitter_description = "SSR dashboard with live API polling.",
+    .extra_head = "<style>" ++ page_css ++ "</style>",
+};
+
 const html_top =
-    \\<!DOCTYPE html>
-    \\<html lang="en">
-    \\<head>
-    \\  <meta charset="UTF-8">
-    \\  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    \\  <title>Dashboard — merjs</title>
-    \\  <meta name="description" content="SSR dashboard with live API polling. Server-side rendered at request time, client polls /api/time every second.">
-    \\  <meta property="og:type" content="website">
-    \\  <meta property="og:site_name" content="merjs">
-    \\  <meta property="og:title" content="Dashboard — merjs">
-    \\  <meta property="og:description" content="SSR + live API polling. Rendered by Zig, zero Node.js.">
-    \\  <meta name="twitter:card" content="summary">
-    \\  <meta name="twitter:title" content="Dashboard — merjs">
-    \\  <meta name="twitter:description" content="SSR dashboard with live API polling.">
-    \\  <link rel="preconnect" href="https://fonts.googleapis.com">
-    \\  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    \\  <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
-    \\  <noscript><link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet"></noscript>
-    \\  <style>
-    \\    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    \\    :root { --bg:#f0ebe3; --bg2:#e8e2d9; --bg3:#ddd5cc; --text:#252530; --muted:#8a7f78; --border:#d5cdc4; --red:#e8251f; }
-    \\    body { background:var(--bg); color:var(--text); font-family:'DM Sans',system-ui,sans-serif; min-height:100vh; }
-    \\    a { color:inherit; text-decoration:none; }
-    \\    .page { max-width:680px; margin:0 auto; padding:48px 32px 96px; }
-    \\    .header { display:flex; align-items:center; justify-content:space-between; margin-bottom:48px; }
-    \\    .wordmark { font-family:'DM Serif Display',Georgia,serif; font-size:18px; letter-spacing:-0.02em; }
-    \\    .wordmark span { color:var(--red); }
-    \\    .back { font-size:13px; color:var(--muted); transition:color 0.15s; }
-    \\    .back:hover { color:var(--text); }
-    \\    h1 { font-family:'DM Serif Display',Georgia,serif; font-size:32px; letter-spacing:-0.02em; margin-bottom:32px; }
-    \\    .card {
-    \\      background:var(--bg2); border:1px solid var(--border);
-    \\      border-radius:12px; padding:24px;
-    \\      margin-bottom:16px;
-    \\    }
-    \\    .card-label {
-    \\      display:flex; align-items:center; gap:8px;
-    \\      font-size:11px; color:var(--muted);
-    \\      text-transform:uppercase; letter-spacing:0.08em;
-    \\      margin-bottom:20px;
-    \\    }
-    \\    .dot { width:7px; height:7px; border-radius:50%; background:var(--muted); flex-shrink:0; }
-    \\    .dot-red { background:var(--red); }
-    \\    .dot-pulse { background:var(--red); animation:pulse 2s infinite; }
-    \\    @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
-    \\    .grid2 { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
-    \\    .stat { background:var(--bg3); border-radius:8px; padding:16px; }
-    \\    .stat-label { font-size:11px; color:var(--muted); margin-bottom:6px; }
-    \\    .stat-value { font-family:'SF Mono','Fira Code',monospace; font-size:15px; color:var(--text); }
-    \\    .stat-value.red { color:var(--red); }
-    \\    .stat-value.big { font-size:28px; }
-    \\    .footer-note { font-size:12px; color:var(--muted); text-align:center; margin-top:24px; }
-    \\    .footer-note code { font-family:'SF Mono',monospace; font-size:11px; background:var(--bg3); padding:1px 5px; border-radius:3px; }
-    \\  </style>
-    \\</head>
-    \\<body>
-    \\<div class="page">
-    \\  <header class="header">
-    \\    <a href="/" class="wordmark">mer<span>js</span></a>
-    \\    <a href="/" class="back">← home</a>
-    \\  </header>
-    \\  <h1>Dashboard</h1>
-    \\  <!-- SSR card -->
-    \\  <div class="card">
-    \\    <div class="card-label">
-    \\      <span class="dot dot-red"></span>
-    \\      Server-side rendered
+    \\<h1>Dashboard</h1>
+    \\<!-- SSR card -->
+    \\<div class="card">
+    \\  <div class="card-label">
+    \\    <span class="dot dot-red"></span>
+    \\    Server-side rendered
+    \\  </div>
+    \\  <div class="grid2">
+    \\    <div class="stat">
+    \\      <div class="stat-label">framework</div>
+    \\      <div class="stat-value red">zig</div>
     \\    </div>
-    \\    <div class="grid2">
-    \\      <div class="stat">
-    \\        <div class="stat-label">framework</div>
-    \\        <div class="stat-value red">zig</div>
-    \\      </div>
-    \\      <div class="stat">
-    \\        <div class="stat-label">node_modules</div>
-    \\        <div class="stat-value red">0</div>
-    \\      </div>
-    \\      <div class="stat" style="grid-column:1/-1">
-    \\        <div class="stat-label">rendered at (unix)</div>
-    \\        <div class="stat-value big" id="ssr-ts">
+    \\    <div class="stat">
+    \\      <div class="stat-label">node_modules</div>
+    \\      <div class="stat-value red">0</div>
+    \\    </div>
+    \\    <div class="stat" style="grid-column:1/-1">
+    \\      <div class="stat-label">rendered at (unix)</div>
+    \\      <div class="stat-value big" id="ssr-ts">
 ;
 
 const html_bottom =
-    \\        </div>
     \\      </div>
-    \\      <div class="stat">
-    \\        <div class="stat-label">human time</div>
-    \\        <div class="stat-value red" id="ssr-human">&mdash;</div>
-    \\      </div>
-    \\      <div class="stat">
-    \\        <div class="stat-label">iso string</div>
-    \\        <div class="stat-value" id="ssr-iso" style="font-size:12px">&mdash;</div>
-    \\      </div>
+    \\    </div>
+    \\    <div class="stat">
+    \\      <div class="stat-label">human time</div>
+    \\      <div class="stat-value red" id="ssr-human">&mdash;</div>
+    \\    </div>
+    \\    <div class="stat">
+    \\      <div class="stat-label">iso string</div>
+    \\      <div class="stat-value" id="ssr-iso" style="font-size:12px">&mdash;</div>
     \\    </div>
     \\  </div>
-    \\  <!-- Live card -->
-    \\  <div class="card">
-    \\    <div class="card-label">
-    \\      <span class="dot dot-pulse"></span>
-    \\      Live &mdash; /api/time
-    \\    </div>
-    \\    <div class="grid2">
-    \\      <div class="stat" style="grid-column:1/-1">
-    \\        <div class="stat-label">current unix timestamp</div>
-    \\        <div class="stat-value big" id="live-ts">—</div>
-    \\      </div>
-    \\      <div class="stat">
-    \\        <div class="stat-label">human time</div>
-    \\        <div class="stat-value red" id="live-human">—</div>
-    \\      </div>
-    \\      <div class="stat">
-    \\        <div class="stat-label">iso string</div>
-    \\        <div class="stat-value" id="live-iso" style="font-size:12px">—</div>
-    \\      </div>
-    \\    </div>
-    \\  </div>
-    \\  <p class="footer-note">
-    \\    Top card baked by Zig at request time &middot;
-    \\    bottom polls <code>/api/time</code> every second
-    \\  </p>
     \\</div>
+    \\<!-- Live card -->
+    \\<div class="card">
+    \\  <div class="card-label">
+    \\    <span class="dot dot-pulse"></span>
+    \\    Live &mdash; /api/time
+    \\  </div>
+    \\  <div class="grid2">
+    \\    <div class="stat" style="grid-column:1/-1">
+    \\      <div class="stat-label">current unix timestamp</div>
+    \\      <div class="stat-value big" id="live-ts">&mdash;</div>
+    \\    </div>
+    \\    <div class="stat">
+    \\      <div class="stat-label">human time</div>
+    \\      <div class="stat-value red" id="live-human">&mdash;</div>
+    \\    </div>
+    \\    <div class="stat">
+    \\      <div class="stat-label">iso string</div>
+    \\      <div class="stat-value" id="live-iso" style="font-size:12px">&mdash;</div>
+    \\    </div>
+    \\  </div>
+    \\</div>
+    \\<p class="footer-note">
+    \\  Top card baked by Zig at request time &middot;
+    \\  bottom polls <code>/api/time</code> every second
+    \\</p>
     \\<script>
     \\  async function tick() {
     \\    const d = await fetch('/api/time').then(r => r.json());
@@ -131,7 +80,6 @@ const html_bottom =
     \\    document.getElementById('live-iso').textContent = d.iso;
     \\  }
     \\  tick(); setInterval(tick, 1000);
-    \\  // Hydrate SSR card with human-readable values
     \\  const ssrTs = parseInt(document.getElementById('ssr-ts').textContent, 10);
     \\  if (ssrTs > 0) {
     \\    const d = new Date(ssrTs * 1000);
@@ -139,8 +87,6 @@ const html_bottom =
     \\    document.getElementById('ssr-iso').textContent = d.toISOString();
     \\  }
     \\</script>
-    \\</body>
-    \\</html>
 ;
 
 pub fn render(req: mer.Request) mer.Response {
@@ -156,3 +102,28 @@ pub fn render(req: mer.Request) mer.Response {
     ) catch return mer.internalError("alloc failed");
     return mer.html(body);
 }
+
+const page_css =
+    \\h1 { font-family:'DM Serif Display',Georgia,serif; font-size:32px; letter-spacing:-0.02em; margin-bottom:32px; }
+    \\.card {
+    \\  background:var(--bg2); border:1px solid var(--border);
+    \\  border-radius:12px; padding:24px; margin-bottom:16px;
+    \\}
+    \\.card-label {
+    \\  display:flex; align-items:center; gap:8px;
+    \\  font-size:11px; color:var(--muted);
+    \\  text-transform:uppercase; letter-spacing:0.08em; margin-bottom:20px;
+    \\}
+    \\.dot { width:7px; height:7px; border-radius:50%; background:var(--muted); flex-shrink:0; }
+    \\.dot-red { background:var(--red); }
+    \\.dot-pulse { background:var(--red); animation:pulse 2s infinite; }
+    \\@keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
+    \\.grid2 { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
+    \\.stat { background:var(--bg3); border-radius:8px; padding:16px; }
+    \\.stat-label { font-size:11px; color:var(--muted); margin-bottom:6px; }
+    \\.stat-value { font-family:'SF Mono','Fira Code',monospace; font-size:15px; color:var(--text); }
+    \\.stat-value.red { color:var(--red); }
+    \\.stat-value.big { font-size:28px; }
+    \\.footer-note { font-size:12px; color:var(--muted); text-align:center; margin-top:24px; }
+    \\.footer-note code { font-family:'SF Mono',monospace; font-size:11px; background:var(--bg3); padding:1px 5px; border-radius:3px; }
+;

--- a/app/users.zig
+++ b/app/users.zig
@@ -8,147 +8,97 @@ const UserModel = mer.dhi.Model("User", .{
     .score = mer.dhi.Float(f64, .{ .ge = 0.0, .le = 100.0 }),
 });
 
-// HTML segments — dynamic slots: initials · name · status · email · age · score · model
+pub const meta: mer.Meta = .{
+    .title = "Users",
+    .description = "Type-safe user profiles validated with dhi. Comptime constraints, zero runtime overhead.",
+    .og_title = "Users \u{2014} merjs",
+    .og_description = "dhi-validated user profiles with comptime type safety.",
+    .twitter_card = "summary",
+    .twitter_title = "Users \u{2014} merjs",
+    .twitter_description = "Type-safe user profiles validated with dhi.",
+    .extra_head = "<style>" ++ page_css ++ "</style>",
+};
+
 const P0 =
-    \\<!DOCTYPE html><html lang="en"><head>
-    \\  <meta charset="UTF-8">
-    \\  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    \\  <title>Users — merjs</title>
-    \\  <meta name="description" content="Type-safe user profiles validated with dhi. Comptime constraints, zero runtime overhead.">
-    \\  <meta property="og:type" content="website">
-    \\  <meta property="og:site_name" content="merjs">
-    \\  <meta property="og:title" content="Users — merjs">
-    \\  <meta property="og:description" content="dhi-validated user profiles with comptime type safety.">
-    \\  <meta name="twitter:card" content="summary">
-    \\  <meta name="twitter:title" content="Users — merjs">
-    \\  <meta name="twitter:description" content="Type-safe user profiles validated with dhi.">
-    \\  <link rel="preconnect" href="https://fonts.googleapis.com">
-    \\  <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
-    \\  <style>
-    \\    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    \\    :root { --bg:#f0ebe3; --bg2:#e8e2d9; --bg3:#ddd5cc; --text:#252530; --muted:#8a7f78; --border:#d5cdc4; --red:#e8251f; }
-    \\    body { background:var(--bg); color:var(--text); font-family:'DM Sans',system-ui,sans-serif; min-height:100vh; }
-    \\    a { color:inherit; text-decoration:none; }
-    \\    .page { max-width:680px; margin:0 auto; padding:48px 32px 96px; }
-    \\    .header { display:flex; align-items:center; justify-content:space-between; margin-bottom:48px; }
-    \\    .wordmark { font-family:'DM Serif Display',Georgia,serif; font-size:18px; letter-spacing:-0.02em; }
-    \\    .wordmark span { color:var(--red); }
-    \\    .back { font-size:13px; color:var(--muted); transition:color 0.15s; }
-    \\    .back:hover { color:var(--text); }
-    \\    h1 { font-family:'DM Serif Display',Georgia,serif; font-size:32px; letter-spacing:-0.02em; margin-bottom:32px; }
-    \\    .card { background:var(--bg2); border:1px solid var(--border); border-radius:12px; padding:24px; margin-bottom:16px; }
-    \\    .card-label { display:flex; align-items:center; gap:8px; font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:0.08em; margin-bottom:20px; }
-    \\    .dot-red { width:7px; height:7px; border-radius:50%; background:var(--red); flex-shrink:0; }
-    \\    .dot-pulse { width:7px; height:7px; border-radius:50%; background:var(--red); flex-shrink:0; animation:pulse 2s infinite; }
-    \\    @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.35} }
-    \\    .profile { display:flex; align-items:center; gap:16px; margin-bottom:20px; }
-    \\    .avatar { width:52px; height:52px; border-radius:10px; background:var(--red); color:var(--bg); display:flex; align-items:center; justify-content:center; font-size:18px; font-weight:600; flex-shrink:0; user-select:none; }
-    \\    .profile-name { font-size:18px; font-weight:600; letter-spacing:-0.01em; }
-    \\    .status { display:inline-flex; font-size:11px; font-weight:600; letter-spacing:0.06em; text-transform:uppercase; background:rgba(232,37,31,0.1); color:var(--red); border:1px solid rgba(232,37,31,0.25); border-radius:100px; padding:3px 10px; margin-left:10px; }
-    \\    .profile-email { font-size:14px; color:var(--muted); margin-top:3px; }
-    \\    .stats { display:grid; grid-template-columns:repeat(3,1fr); gap:10px; }
-    \\    .stat { background:var(--bg3); border-radius:8px; padding:14px; }
-    \\    .stat-label { font-size:11px; color:var(--muted); margin-bottom:5px; }
-    \\    .stat-value { font-family:'SF Mono','Fira Code',monospace; font-size:15px; color:var(--text); }
-    \\    .stat-value.red { color:var(--red); }
-    \\    pre { background:var(--bg3); border:1px solid var(--border); border-radius:8px; padding:18px; font-family:'SF Mono','Fira Code',monospace; font-size:13px; line-height:1.7; overflow-x:auto; color:var(--text); }
-    \\    pre .k { color:var(--red); }
-    \\    pre .s { color:#7a6b5a; }
-    \\    pre .n { color:#5a5060; }
-    \\    pre .v { color:#252530; font-weight:500; }
-    \\    #api-out { color:var(--muted); }
-    \\    .footer-note { font-size:12px; color:var(--muted); text-align:center; margin-top:16px; }
-    \\    .footer-note a { border-bottom:1px solid var(--border); }
-    \\    .footer-note a:hover { color:var(--text); }
-    \\  </style>
-    \\</head>
-    \\<body>
-    \\<div class="page">
-    \\  <header class="header">
-    \\    <a href="/" class="wordmark">mer<span>js</span></a>
-    \\    <a href="/" class="back">← home</a>
-    \\  </header>
-    \\  <h1>Users</h1>
-    \\  <div class="card">
-    \\    <div class="card-label"><span class="dot-red"></span> Server-side rendered &middot; dhi validated</div>
-    \\    <div class="profile">
-    \\      <div class="avatar">
-; // initials
+    \\<h1>Users</h1>
+    \\<div class="card">
+    \\  <div class="card-label"><span class="dot-red"></span> Server-side rendered &middot; dhi validated</div>
+    \\  <div class="profile">
+    \\    <div class="avatar">
+;
 
 const P1 =
-    \\      </div>
-    \\      <div>
-    \\        <div class="profile-name">
-; // name
+    \\    </div>
+    \\    <div>
+    \\      <div class="profile-name">
+;
 
 const P2 =
-    \\          <span class="status">
-; // status
+    \\        <span class="status">
+;
 
 const P3 =
-    \\          </span>
-    \\        </div>
-    \\        <div class="profile-email">
-; // email
+    \\        </span>
+    \\      </div>
+    \\      <div class="profile-email">
+;
 
 const P4 =
-    \\        </div>
     \\      </div>
     \\    </div>
-    \\    <div class="stats">
-    \\      <div class="stat">
-    \\        <div class="stat-label">age</div>
-    \\        <div class="stat-value">
-; // age
+    \\  </div>
+    \\  <div class="stats">
+    \\    <div class="stat">
+    \\      <div class="stat-label">age</div>
+    \\      <div class="stat-value">
+;
 
 const P5 =
-    \\        </div>
     \\      </div>
-    \\      <div class="stat">
-    \\        <div class="stat-label">score</div>
-    \\        <div class="stat-value red">
-; // score
+    \\    </div>
+    \\    <div class="stat">
+    \\      <div class="stat-label">score</div>
+    \\      <div class="stat-value red">
+;
 
 const P6 =
-    \\        </div>
     \\      </div>
-    \\      <div class="stat">
-    \\        <div class="stat-label">model</div>
-    \\        <div class="stat-value" style="font-size:12px">
-; // model name
+    \\    </div>
+    \\    <div class="stat">
+    \\      <div class="stat-label">model</div>
+    \\      <div class="stat-value" style="font-size:12px">
+;
 
 const P7 =
-    \\        </div>
     \\      </div>
     \\    </div>
     \\  </div>
-    \\  <!-- dhi schema -->
-    \\  <div class="card">
-    \\    <div class="card-label"><span class="dot-red"></span> dhi schema &middot; compile-time validation</div>
-    \\    <pre><span class="k">const</span> UserModel = <span class="n">mer.dhi.Model</span>(<span class="s">"User"</span>, .{
-    \\    .name  = <span class="n">dhi.Str</span>(.{ .min_length=<span class="v">1</span>, .max_length=<span class="v">100</span> }),
-    \\    .email = <span class="n">dhi.EmailStr</span>,
-    \\    .age   = <span class="n">dhi.Int</span>(i32, .{ .gt=<span class="v">0</span>, .le=<span class="v">150</span> }),
-    \\    .score = <span class="n">dhi.Float</span>(f64, .{ .ge=<span class="v">0.0</span>, .le=<span class="v">100.0</span> }),
-    \\});</pre>
-    \\  </div>
-    \\  <!-- live API -->
-    \\  <div class="card">
-    \\    <div class="card-label"><span class="dot-pulse"></span> Live &mdash; /api/users</div>
-    \\    <pre id="api-out">fetching…</pre>
-    \\  </div>
-    \\  <p class="footer-note">
-    \\    Validated with <a href="https://github.com/justrach/dhi">dhi</a>
-    \\    at compile time &middot; zero runtime schema overhead
-    \\  </p>
     \\</div>
+    \\<!-- dhi schema -->
+    \\<div class="card">
+    \\  <div class="card-label"><span class="dot-red"></span> dhi schema &middot; compile-time validation</div>
+    \\  <pre><span class="k">const</span> UserModel = <span class="n">mer.dhi.Model</span>(<span class="s">"User"</span>, .{
+    \\  .name  = <span class="n">dhi.Str</span>(.{ .min_length=<span class="v">1</span>, .max_length=<span class="v">100</span> }),
+    \\  .email = <span class="n">dhi.EmailStr</span>,
+    \\  .age   = <span class="n">dhi.Int</span>(i32, .{ .gt=<span class="v">0</span>, .le=<span class="v">150</span> }),
+    \\  .score = <span class="n">dhi.Float</span>(f64, .{ .ge=<span class="v">0.0</span>, .le=<span class="v">100.0</span> }),
+    \\});</pre>
+    \\</div>
+    \\<!-- live API -->
+    \\<div class="card">
+    \\  <div class="card-label"><span class="dot-pulse"></span> Live &mdash; /api/users</div>
+    \\  <pre id="api-out">fetching&hellip;</pre>
+    \\</div>
+    \\<p class="footer-note">
+    \\  Validated with <a href="https://github.com/justrach/dhi">dhi</a>
+    \\  at compile time &middot; zero runtime schema overhead
+    \\</p>
     \\<script>
     \\  fetch('/api/users')
     \\    .then(r => r.json())
     \\    .then(d => { document.getElementById('api-out').textContent = JSON.stringify(d, null, 2); })
     \\    .catch(e => { document.getElementById('api-out').textContent = 'error: ' + e; });
     \\</script>
-    \\</body></html>
 ;
 
 fn initials(name: []const u8, buf: *[2]u8) []const u8 {
@@ -193,3 +143,31 @@ pub fn render(req: mer.Request) mer.Response {
 
     return mer.html(page);
 }
+
+const page_css =
+    \\h1 { font-family:'DM Serif Display',Georgia,serif; font-size:32px; letter-spacing:-0.02em; margin-bottom:32px; }
+    \\.card { background:var(--bg2); border:1px solid var(--border); border-radius:12px; padding:24px; margin-bottom:16px; }
+    \\.card-label { display:flex; align-items:center; gap:8px; font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:0.08em; margin-bottom:20px; }
+    \\.dot-red { width:7px; height:7px; border-radius:50%; background:var(--red); flex-shrink:0; }
+    \\.dot-pulse { width:7px; height:7px; border-radius:50%; background:var(--red); flex-shrink:0; animation:pulse 2s infinite; }
+    \\@keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.35} }
+    \\.profile { display:flex; align-items:center; gap:16px; margin-bottom:20px; }
+    \\.avatar { width:52px; height:52px; border-radius:10px; background:var(--red); color:var(--bg); display:flex; align-items:center; justify-content:center; font-size:18px; font-weight:600; flex-shrink:0; user-select:none; }
+    \\.profile-name { font-size:18px; font-weight:600; letter-spacing:-0.01em; }
+    \\.status { display:inline-flex; font-size:11px; font-weight:600; letter-spacing:0.06em; text-transform:uppercase; background:rgba(232,37,31,0.1); color:var(--red); border:1px solid rgba(232,37,31,0.25); border-radius:100px; padding:3px 10px; margin-left:10px; }
+    \\.profile-email { font-size:14px; color:var(--muted); margin-top:3px; }
+    \\.stats { display:grid; grid-template-columns:repeat(3,1fr); gap:10px; }
+    \\.stat { background:var(--bg3); border-radius:8px; padding:14px; }
+    \\.stat-label { font-size:11px; color:var(--muted); margin-bottom:5px; }
+    \\.stat-value { font-family:'SF Mono','Fira Code',monospace; font-size:15px; color:var(--text); }
+    \\.stat-value.red { color:var(--red); }
+    \\pre { background:var(--bg3); border:1px solid var(--border); border-radius:8px; padding:18px; font-family:'SF Mono','Fira Code',monospace; font-size:13px; line-height:1.7; overflow-x:auto; color:var(--text); }
+    \\pre .k { color:var(--red); }
+    \\pre .s { color:#7a6b5a; }
+    \\pre .n { color:#5a5060; }
+    \\pre .v { color:#252530; font-weight:500; }
+    \\#api-out { color:var(--muted); }
+    \\.footer-note { font-size:12px; color:var(--muted); text-align:center; margin-top:16px; }
+    \\.footer-note a { border-bottom:1px solid var(--border); }
+    \\.footer-note a:hover { color:var(--text); }
+;

--- a/app/weather.zig
+++ b/app/weather.zig
@@ -3,10 +3,11 @@ const mer = @import("mer");
 pub const meta: mer.Meta = .{
     .title = "Weather",
     .description = "Live weather dashboard powered by Open-Meteo. Temperature, precipitation, wind, and 7-day forecast.",
-    .og_title = "merjs Weather — Live Global Forecasts",
+    .og_title = "merjs Weather \u{2014} Live Global Forecasts",
     .og_description = "Real-time weather data rendered by a Zig web framework with zero Node.js.",
     .og_type = "website",
     .twitter_card = "summary_large_image",
+    .extra_head = "<script src=\"https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js\"></script><style>" ++ page_css ++ "</style>",
 };
 
 pub fn render(req: mer.Request) mer.Response {
@@ -15,77 +16,7 @@ pub fn render(req: mer.Request) mer.Response {
 }
 
 const html =
-    \\<!DOCTYPE html>
-    \\<html lang="en">
-    \\<head>
-    \\  <meta charset="UTF-8">
-    \\  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    \\  <title>Weather — merjs</title>
-    \\  <meta name="description" content="Live weather dashboard powered by Open-Meteo. Temperature, precipitation, wind, and 7-day forecast.">
-    \\  <meta property="og:type" content="website">
-    \\  <meta property="og:site_name" content="merjs">
-    \\  <meta property="og:title" content="merjs Weather — Live Global Forecasts">
-    \\  <meta property="og:description" content="Real-time weather data rendered by a Zig web framework with zero Node.js.">
-    \\  <meta name="twitter:card" content="summary_large_image">
-    \\  <meta name="twitter:title" content="merjs Weather — Live Global Forecasts">
-    \\  <meta name="twitter:description" content="Live weather dashboard powered by Open-Meteo, served by Zig.">
-    \\  <link rel="preconnect" href="https://fonts.googleapis.com">
-    \\  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    \\  <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
-    \\  <noscript><link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet"></noscript>
-    \\  <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
-    \\  <style>
-    \\    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    \\    :root { --bg:#f0ebe3; --bg2:#e8e2d9; --bg3:#ddd5cc; --text:#252530; --muted:#8a7f78; --border:#d5cdc4; --red:#e8251f; }
-    \\    body { background:var(--bg); color:var(--text); font-family:'DM Sans',system-ui,sans-serif; min-height:100vh; }
-    \\    a { color:inherit; text-decoration:none; }
-    \\    .page { max-width:780px; margin:0 auto; padding:48px 32px 96px; }
-    \\    .header { display:flex; align-items:center; justify-content:space-between; margin-bottom:48px; }
-    \\    .wordmark { font-family:'DM Serif Display',Georgia,serif; font-size:18px; letter-spacing:-0.02em; }
-    \\    .wordmark span { color:var(--red); }
-    \\    .back { font-size:13px; color:var(--muted); transition:color 0.15s; }
-    \\    .back:hover { color:var(--text); }
-    \\    h1 { font-family:'DM Serif Display',Georgia,serif; font-size:32px; letter-spacing:-0.02em; margin-bottom:8px; }
-    \\    .subtitle { font-size:14px; color:var(--muted); margin-bottom:32px; }
-    \\    .card { background:var(--bg2); border:1px solid var(--border); border-radius:12px; padding:24px; margin-bottom:16px; }
-    \\    .card-label { display:flex; align-items:center; gap:8px; font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:0.08em; margin-bottom:20px; }
-    \\    .dot { width:7px; height:7px; border-radius:50%; flex-shrink:0; }
-    \\    .dot-red { background:var(--red); }
-    \\    .dot-pulse { background:var(--red); animation:pulse 2s infinite; }
-    \\    .dot-blue { background:#3b82f6; }
-    \\    .dot-green { background:#22c55e; }
-    \\    @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
-    \\    .grid2 { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
-    \\    .grid3 { display:grid; grid-template-columns:1fr 1fr 1fr; gap:12px; }
-    \\    .grid4 { display:grid; grid-template-columns:1fr 1fr 1fr 1fr; gap:12px; }
-    \\    .stat { background:var(--bg3); border-radius:8px; padding:16px; }
-    \\    .stat-label { font-size:11px; color:var(--muted); margin-bottom:6px; }
-    \\    .stat-value { font-family:'SF Mono','Fira Code',monospace; font-size:15px; color:var(--text); }
-    \\    .stat-value.red { color:var(--red); }
-    \\    .stat-value.big { font-size:28px; }
-    \\    .stat-value.huge { font-size:40px; letter-spacing:-0.03em; }
-    \\    .stat-unit { font-size:11px; color:var(--muted); margin-left:2px; }
-    \\    .chart-wrap { position:relative; height:220px; margin-top:12px; }
-    \\    .chart-wrap canvas { width:100%!important; height:100%!important; }
-    \\    .location-bar { display:flex; gap:8px; margin-bottom:24px; flex-wrap:wrap; }
-    \\    .loc-btn { background:var(--bg3); border:1px solid var(--border); border-radius:8px; padding:8px 16px; font-size:13px; font-family:'DM Sans',sans-serif; color:var(--text); cursor:pointer; transition:all 0.15s; }
-    \\    .loc-btn:hover { background:var(--border); }
-    \\    .loc-btn.active { background:var(--text); color:var(--bg); border-color:var(--text); }
-    \\    .weather-icon { font-size:48px; line-height:1; }
-    \\    .loading { text-align:center; padding:40px; color:var(--muted); font-size:14px; }
-    \\    .footer-note { font-size:12px; color:var(--muted); text-align:center; margin-top:24px; }
-    \\    .footer-note a { text-decoration:underline; text-underline-offset:2px; }
-    \\    .footer-note code { font-family:'SF Mono',monospace; font-size:11px; background:var(--bg3); padding:1px 5px; border-radius:3px; }
-    \\    @media(max-width:640px) { .grid3,.grid4 { grid-template-columns:1fr 1fr; } }
-    \\  </style>
-    \\</head>
-    \\<body>
-    \\<div class="page">
-    \\  <header class="header">
-    \\    <a href="/" class="wordmark">mer<span>js</span></a>
-    \\    <a href="/" class="back">&larr; home</a>
-    \\  </header>
-    \\  <h1>Weather</h1>
+    \\<h1>Weather</h1>
     \\  <p class="subtitle">Live data from Open-Meteo &mdash; rendered client-side, fetched from a free API, charted with Chart.js</p>
     \\
     \\  <div class="location-bar" id="locations">
@@ -178,7 +109,6 @@ const html =
     \\      and the route is live. The charts fetch from Open-Meteo client-side &mdash; zero backend proxy needed.
     \\    </p>
     \\  </div>
-    \\</div>
     \\
     \\<script>
     \\const WMO = {0:'Clear',1:'Mostly Clear',2:'Partly Cloudy',3:'Overcast',
@@ -303,6 +233,39 @@ const html =
     \\initCharts();
     \\loadCity(1.29, 103.85);
     \\</script>
-    \\</body>
-    \\</html>
+;
+
+const page_css =
+    \\h1 { font-family:'DM Serif Display',Georgia,serif; font-size:32px; letter-spacing:-0.02em; margin-bottom:8px; }
+    \\.subtitle { font-size:14px; color:var(--muted); margin-bottom:32px; }
+    \\.card { background:var(--bg2); border:1px solid var(--border); border-radius:12px; padding:24px; margin-bottom:16px; }
+    \\.card-label { display:flex; align-items:center; gap:8px; font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:0.08em; margin-bottom:20px; }
+    \\.dot { width:7px; height:7px; border-radius:50%; flex-shrink:0; }
+    \\.dot-red { background:var(--red); }
+    \\.dot-pulse { background:var(--red); animation:pulse 2s infinite; }
+    \\.dot-blue { background:#3b82f6; }
+    \\.dot-green { background:#22c55e; }
+    \\@keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
+    \\.grid2 { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
+    \\.grid3 { display:grid; grid-template-columns:1fr 1fr 1fr; gap:12px; }
+    \\.grid4 { display:grid; grid-template-columns:1fr 1fr 1fr 1fr; gap:12px; }
+    \\.stat { background:var(--bg3); border-radius:8px; padding:16px; }
+    \\.stat-label { font-size:11px; color:var(--muted); margin-bottom:6px; }
+    \\.stat-value { font-family:'SF Mono','Fira Code',monospace; font-size:15px; color:var(--text); }
+    \\.stat-value.red { color:var(--red); }
+    \\.stat-value.big { font-size:28px; }
+    \\.stat-value.huge { font-size:40px; letter-spacing:-0.03em; }
+    \\.stat-unit { font-size:11px; color:var(--muted); margin-left:2px; }
+    \\.chart-wrap { position:relative; height:220px; margin-top:12px; }
+    \\.chart-wrap canvas { width:100%!important; height:100%!important; }
+    \\.location-bar { display:flex; gap:8px; margin-bottom:24px; flex-wrap:wrap; }
+    \\.loc-btn { background:var(--bg3); border:1px solid var(--border); border-radius:8px; padding:8px 16px; font-size:13px; font-family:'DM Sans',sans-serif; color:var(--text); cursor:pointer; transition:all 0.15s; }
+    \\.loc-btn:hover { background:var(--border); }
+    \\.loc-btn.active { background:var(--text); color:var(--bg); border-color:var(--text); }
+    \\.weather-icon { font-size:48px; line-height:1; }
+    \\.loading { text-align:center; padding:40px; color:var(--muted); font-size:14px; }
+    \\.footer-note { font-size:12px; color:var(--muted); text-align:center; margin-top:24px; }
+    \\.footer-note a { text-decoration:underline; text-underline-offset:2px; }
+    \\.footer-note code { font-family:'SF Mono',monospace; font-size:11px; background:var(--bg3); padding:1px 5px; border-radius:3px; }
+    \\@media(max-width:640px) { .grid3,.grid4 { grid-template-columns:1fr 1fr; } }
 ;

--- a/tools/codegen.zig
+++ b/tools/codegen.zig
@@ -56,6 +56,16 @@ pub fn main() !void {
     }
     try w.writeAll("};\n\n");
 
+    // Enforce: every app/ page must export `pub const meta: mer.Meta`.
+    try w.writeAll("comptime {\n");
+    for (entries.items) |path| {
+        if (!std.mem.startsWith(u8, path, "app/")) continue;
+        const ident = try toIdent(alloc, path);
+        defer alloc.free(ident);
+        try w.print("    if (!@hasDecl({s}, \"meta\")) @compileError(\"{s} must export pub const meta: mer.Meta\");\n", .{ ident, path });
+    }
+    try w.writeAll("}\n\n");
+
     // --- Framework primitives (auto-detected) ---
 
     // Layout — if app/layout.zig exists, export its wrap function.


### PR DESCRIPTION
Closes #15, closes #16, closes #17, closes #18

**What changed:**

### Codegen enforcement (#15)
`tools/codegen.zig` now emits a comptime assertion for every `app/` page:
```zig
if (!@hasDecl(app_dashboard, "meta")) @compileError("app/dashboard.zig must export pub const meta: mer.Meta");
```
Any new page without `pub const meta` **will not compile**.

### Dashboard (#16)
- Added `pub const meta: mer.Meta`
- Removed 60+ lines of HTML/CSS boilerplate (layout wraps automatically)
- Kept dynamic SSR timestamp + `/api/time` polling

### Users (#17)
- Added `pub const meta: mer.Meta`
- Removed HTML boilerplate, layout-wrapped
- Dhi `UserModel` validation unchanged

### Weather (#18)
- Stripped `<!DOCTYPE>` boilerplate (was 70+ lines)
- Chart.js loaded via `meta.extra_head`
- Layout wraps automatically, all charts/scripts preserved

**Net: -78 lines of duplicated boilerplate**