### PR TITLE
feat: query params, redirect helper, and cookie parsing

### DIFF
--- a/src/mer.zig
+++ b/src/mer.zig
@@ -18,16 +18,38 @@ pub const text          = res_mod.text;
 pub const notFound      = res_mod.notFound;
 pub const internalError = res_mod.internalError;
 
+/// HTTP redirect.
+///
+///   return mer.redirect("/login", .found);          // 302
+///   return mer.redirect("/dashboard", .see_other);  // 303 after POST
+pub const redirect = res_mod.redirect;
+
 /// Serialize any struct to a JSON response (type-safe alternative to `json()`).
 ///
 ///   const TimeResp = struct { timestamp: i64, unit: []const u8 };
 ///   return mer.typedJson(req.allocator, TimeResp{ .timestamp = ts, .unit = "s" });
 pub fn typedJson(allocator: std.mem.Allocator, value: anytype) Response {
     var out: std.io.Writer.Allocating = .init(allocator);
-    // No deinit needed — arena allocator owns the memory for the lifetime of the request.
     var jw: std.json.Stringify = .{ .writer = &out.writer };
     jw.write(value) catch return internalError("json write failed");
     return res_mod.Response.init(.ok, .json, out.written());
+}
+
+/// Parse a JSON request body into type T.
+///
+///   const Body = struct { name: []const u8, age: u32 };
+///   const body = try mer.parseJson(Body, req) orelse return mer.badRequest("empty body");
+///   _ = body.value; // remember to call body.deinit() when done
+///
+/// Returns null for an empty body. Caller owns the parsed value (call `.deinit()`).
+pub fn parseJson(comptime T: type, req: Request) !?std.json.Parsed(T) {
+    if (req.body.len == 0) return null;
+    return std.json.parseFromSlice(T, req.allocator, req.body, .{ .ignore_unknown_fields = true });
+}
+
+/// 400 Bad Request response with a plain-text message.
+pub fn badRequest(msg: []const u8) Response {
+    return res_mod.Response.init(.bad_request, .text, msg);
 }
 
 // --- SEO / Meta tags --------------------------------------------------------

--- a/src/request.zig
+++ b/src/request.zig
@@ -12,24 +12,155 @@ pub const Method = enum {
 
     pub fn fromStd(m: std.http.Method) Method {
         return switch (m) {
-            .GET => .GET,
-            .POST => .POST,
-            .PUT => .PUT,
-            .DELETE => .DELETE,
-            .PATCH => .PATCH,
-            .HEAD => .HEAD,
+            .GET     => .GET,
+            .POST    => .POST,
+            .PUT     => .PUT,
+            .DELETE  => .DELETE,
+            .PATCH   => .PATCH,
+            .HEAD    => .HEAD,
             .OPTIONS => .OPTIONS,
-            else => .unknown,
+            else     => .unknown,
         };
     }
 };
 
 pub const Request = struct {
-    method: Method,
-    path: []const u8,
-    allocator: std.mem.Allocator,
+    method:       Method,
+    path:         []const u8,
+    /// Raw query string (everything after `?`, without the `?`).
+    /// Empty slice when no query string is present.
+    query_string: []const u8,
+    /// Raw request body bytes.
+    /// Empty slice for GET / HEAD / requests with no body.
+    body:         []const u8,
+    /// Raw `Cookie:` header value.
+    /// Empty slice when no cookie header is present.
+    cookies_raw:  []const u8,
+    allocator:    std.mem.Allocator,
 
-    pub fn init(allocator: std.mem.Allocator, method: Method, path: []const u8) Request {
-        return .{ .allocator = allocator, .method = method, .path = path };
+    pub fn init(
+        allocator: std.mem.Allocator,
+        method: Method,
+        path: []const u8,
+    ) Request {
+        return .{
+            .allocator    = allocator,
+            .method       = method,
+            .path         = path,
+            .query_string = "",
+            .body         = "",
+            .cookies_raw  = "",
+        };
+    }
+
+    // ── Query parameters ───────────────────────────────────────────────────
+
+    /// Return the value of a query parameter, or null if absent.
+    ///
+    ///   // URL: /search?q=zig&page=2
+    ///   req.queryParam("q")    // → "zig"
+    ///   req.queryParam("page") // → "2"
+    ///   req.queryParam("x")    // → null
+    pub fn queryParam(self: Request, name: []const u8) ?[]const u8 {
+        return queryParamFromStr(self.query_string, name);
+    }
+
+    /// Collect all query params into a StringHashMap.
+    /// Caller owns the map (call `.deinit()` when done).
+    pub fn queryParams(self: Request) std.StringHashMap([]const u8) {
+        var map = std.StringHashMap([]const u8).init(self.allocator);
+        var rest = self.query_string;
+        while (rest.len > 0) {
+            const amp = std.mem.indexOfScalar(u8, rest, '&') orelse rest.len;
+            const kv  = rest[0..amp];
+            if (std.mem.indexOfScalar(u8, kv, '=')) |eq| {
+                map.put(kv[0..eq], kv[eq + 1 ..]) catch {};
+            }
+            rest = if (amp < rest.len) rest[amp + 1 ..] else "";
+        }
+        return map;
+    }
+
+    // ── Cookies ────────────────────────────────────────────────────────────
+
+    /// Return the value of a cookie, or null if absent.
+    ///
+    ///   // Cookie: session=abc123; theme=dark
+    ///   req.cookie("session") // → "abc123"
+    ///   req.cookie("theme")   // → "dark"
+    pub fn cookie(self: Request, name: []const u8) ?[]const u8 {
+        var rest = self.cookies_raw;
+        while (rest.len > 0) {
+            // Trim leading whitespace.
+            while (rest.len > 0 and rest[0] == ' ') rest = rest[1..];
+            const semi = std.mem.indexOfScalar(u8, rest, ';') orelse rest.len;
+            const pair = rest[0..semi];
+            if (std.mem.indexOfScalar(u8, pair, '=')) |eq| {
+                const k = std.mem.trim(u8, pair[0..eq], " ");
+                if (std.mem.eql(u8, k, name)) return pair[eq + 1 ..];
+            }
+            rest = if (semi < rest.len) rest[semi + 1 ..] else "";
+        }
+        return null;
     }
 };
+
+// ── Internal helpers ───────────────────────────────────────────────────────
+
+/// Extract a named query param from a raw query string (no `?` prefix).
+pub fn queryParamFromStr(query: []const u8, name: []const u8) ?[]const u8 {
+    var rest = query;
+    while (rest.len > 0) {
+        const amp = std.mem.indexOfScalar(u8, rest, '&') orelse rest.len;
+        const kv  = rest[0..amp];
+        if (std.mem.indexOfScalar(u8, kv, '=')) |eq| {
+            if (std.mem.eql(u8, kv[0..eq], name)) return kv[eq + 1 ..];
+        }
+        rest = if (amp < rest.len) rest[amp + 1 ..] else "";
+    }
+    return null;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+test "queryParam: basic key=value" {
+    var req = Request.init(std.testing.allocator, .GET, "/search");
+    req.query_string = "q=zig&page=2";
+    try std.testing.expectEqualStrings("zig", req.queryParam("q").?);
+    try std.testing.expectEqualStrings("2",   req.queryParam("page").?);
+}
+
+test "queryParam: missing key returns null" {
+    var req = Request.init(std.testing.allocator, .GET, "/");
+    req.query_string = "a=1";
+    try std.testing.expect(req.queryParam("b") == null);
+}
+
+test "queryParam: empty query string returns null" {
+    const req = Request.init(std.testing.allocator, .GET, "/");
+    try std.testing.expect(req.queryParam("x") == null);
+}
+
+test "queryParam: single param, no ampersand" {
+    var req = Request.init(std.testing.allocator, .GET, "/");
+    req.query_string = "only=one";
+    try std.testing.expectEqualStrings("one", req.queryParam("only").?);
+}
+
+test "cookie: basic name=value" {
+    var req = Request.init(std.testing.allocator, .GET, "/");
+    req.cookies_raw = "session=abc123; theme=dark";
+    try std.testing.expectEqualStrings("abc123", req.cookie("session").?);
+    try std.testing.expectEqualStrings("dark",   req.cookie("theme").?);
+}
+
+test "cookie: missing name returns null" {
+    var req = Request.init(std.testing.allocator, .GET, "/");
+    req.cookies_raw = "a=1";
+    try std.testing.expect(req.cookie("b") == null);
+}
+
+test "cookie: empty cookies_raw returns null" {
+    const req = Request.init(std.testing.allocator, .GET, "/");
+    try std.testing.expect(req.cookie("session") == null);
+}

--- a/src/response.zig
+++ b/src/response.zig
@@ -14,35 +14,40 @@ pub const ContentType = enum {
     ico,
     webp,
     octet_stream,
+    /// Internal sentinel used by redirect(). server.zig emits Location header.
+    redirect,
 
     pub fn mime(self: ContentType) []const u8 {
         return switch (self) {
-            .html => "text/html; charset=utf-8",
-            .json => "application/json",
-            .text => "text/plain; charset=utf-8",
-            .css  => "text/css; charset=utf-8",
-            .js   => "application/javascript",
-            .wasm => "application/wasm",
-            .png  => "image/png",
-            .jpeg => "image/jpeg",
-            .gif  => "image/gif",
-            .svg  => "image/svg+xml",
-            .ico  => "image/x-icon",
-            .webp => "image/webp",
+            .html         => "text/html; charset=utf-8",
+            .json         => "application/json",
+            .text         => "text/plain; charset=utf-8",
+            .css          => "text/css; charset=utf-8",
+            .js           => "application/javascript",
+            .wasm         => "application/wasm",
+            .png          => "image/png",
+            .jpeg         => "image/jpeg",
+            .gif          => "image/gif",
+            .svg          => "image/svg+xml",
+            .ico          => "image/x-icon",
+            .webp         => "image/webp",
             .octet_stream => "application/octet-stream",
+            .redirect     => "text/html; charset=utf-8",
         };
     }
 };
 
 pub const Response = struct {
-    status: std.http.Status,
+    status:       std.http.Status,
     content_type: ContentType,
-    body: []const u8,
+    body:         []const u8,
 
     pub fn init(status: std.http.Status, ct: ContentType, body: []const u8) Response {
         return .{ .status = status, .content_type = ct, .body = body };
     }
 };
+
+// ── Response helpers ───────────────────────────────────────────────────────
 
 pub fn html(body: []const u8) Response {
     return Response.init(.ok, .html, body);
@@ -62,4 +67,14 @@ pub fn notFound() Response {
 
 pub fn internalError(msg: []const u8) Response {
     return Response.init(.internal_server_error, .html, msg);
+}
+
+/// HTTP redirect. `location` must be a stable slice (comptime string or arena).
+///
+///   return mer.redirect("/login", .found);               // 302
+///   return mer.redirect("/dashboard", .see_other);       // 303 — after POST
+///   return mer.redirect("/new-path", .moved_permanently);// 301
+pub fn redirect(location: []const u8, status: std.http.Status) Response {
+    // body carries the Location URL; server.zig detects content_type == .redirect.
+    return .{ .status = status, .content_type = .redirect, .body = location };
 }

--- a/src/server.zig
+++ b/src/server.zig
@@ -23,15 +23,15 @@ pub const security_headers = [_]std.http.Header{
 pub const Config = struct {
     host: []const u8 = "127.0.0.1",
     port: u16 = 3000,
-    dev: bool = false,
+    dev:  bool = false,
 };
 
 pub const Server = struct {
-    config: Config,
-    router: *const Router,
-    watcher: ?*watcher_mod.Watcher,
+    config:    Config,
+    router:    *const Router,
+    watcher:   ?*watcher_mod.Watcher,
     allocator: std.mem.Allocator,
-    pool: std.Thread.Pool,
+    pool:      std.Thread.Pool,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -41,10 +41,10 @@ pub const Server = struct {
     ) Server {
         return .{
             .allocator = allocator,
-            .config = config,
-            .router = router,
-            .watcher = watcher,
-            .pool = undefined,
+            .config    = config,
+            .router    = router,
+            .watcher   = watcher,
+            .pool      = undefined,
         };
     }
 
@@ -68,11 +68,11 @@ pub const Server = struct {
                 continue;
             };
             ctx.* = .{
-                .conn = conn,
-                .router = self.router,
-                .watcher = self.watcher,
+                .conn      = conn,
+                .router    = self.router,
+                .watcher   = self.watcher,
                 .allocator = self.allocator,
-                .dev = self.config.dev,
+                .dev       = self.config.dev,
             };
             self.pool.spawn(handleConn, .{ctx}) catch {
                 ctx.allocator.destroy(ctx);
@@ -83,11 +83,11 @@ pub const Server = struct {
 };
 
 const ConnCtx = struct {
-    conn: std.net.Server.Connection,
-    router: *const Router,
-    watcher: ?*watcher_mod.Watcher,
+    conn:      std.net.Server.Connection,
+    router:    *const Router,
+    watcher:   ?*watcher_mod.Watcher,
     allocator: std.mem.Allocator,
-    dev: bool,
+    dev:       bool,
 };
 
 fn handleConn(ctx: *ConnCtx) void {
@@ -98,11 +98,9 @@ fn handleConn(ctx: *ConnCtx) void {
     defer arena.deinit();
     const alloc = arena.allocator();
 
-    // Zig 0.15: net.Stream.reader/writer return typed wrappers;
-    // call .interface() to get the *Io.Reader / *Io.Writer http.Server needs.
     var read_buf: [8192]u8 = undefined;
     var write_buf: [4096]u8 = undefined;
-    var in = ctx.conn.stream.reader(&read_buf);
+    var in  = ctx.conn.stream.reader(&read_buf);
     var out = ctx.conn.stream.writer(&write_buf);
     var http_server = std.http.Server.init(in.interface(), &out.interface);
 
@@ -128,11 +126,18 @@ fn serveRequest(
     watcher: ?*watcher_mod.Watcher,
     dev: bool,
 ) !void {
-    const raw_path = std_req.head.target;
-    const path = if (std.mem.indexOfScalar(u8, raw_path, '?')) |q|
-        raw_path[0..q]
+    const raw_target = std_req.head.target;
+
+    // Split path and query string.
+    const path: []const u8 = if (std.mem.indexOfScalar(u8, raw_target, '?')) |q|
+        raw_target[0..q]
     else
-        raw_path;
+        raw_target;
+
+    const query_string: []const u8 = if (std.mem.indexOfScalar(u8, raw_target, '?')) |q|
+        if (q + 1 < raw_target.len) raw_target[q + 1 ..] else ""
+    else
+        "";
 
     // SSE hot-reload endpoint.
     if (dev and std.mem.eql(u8, path, "/_mer/events")) {
@@ -152,9 +157,48 @@ fn serveRequest(
         if (tryServePrerendered(alloc, std_req, path)) |_| return;
     }
 
-    // Page router.
-    const req = mer.Request.init(alloc, mer.Method.fromStd(std_req.head.method), path);
+    // ── Build Request ──────────────────────────────────────────────────────
+
+    // Read Cookie header.
+    const cookies_raw: []const u8 = blk: {
+        for (std_req.head.iterateHeaders()) |hdr| {
+            if (std.ascii.eqlIgnoreCase(hdr.name, "cookie")) break :blk hdr.value;
+        }
+        break :blk "";
+    };
+
+    // Read request body (up to 4 MiB).
+    const body_bytes: []const u8 = blk: {
+        var transfer_buf: [4096]u8 = undefined;
+        var br = std_req.server.reader.bodyReader(
+            &transfer_buf,
+            std_req.head.transfer_encoding,
+            std_req.head.content_length,
+        );
+        break :blk br.allocRemaining(alloc, .limited(4 * 1024 * 1024)) catch "";
+    };
+
+    var req = mer.Request.init(alloc, mer.Method.fromStd(std_req.head.method), path);
+    req.query_string = query_string;
+    req.body         = body_bytes;
+    req.cookies_raw  = cookies_raw;
+
     var response = router.dispatch(req);
+
+    // Handle redirects — emit Location header, no body needed.
+    if (response.content_type == .redirect) {
+        var header_buf: [512]u8 = undefined;
+        var bw = try std_req.respondStreaming(&header_buf, .{
+            .respond_options = .{
+                .status = response.status,
+                .extra_headers = &.{
+                    .{ .name = "location", .value = response.body },
+                },
+            },
+        });
+        try bw.end();
+        return;
+    }
 
     // Dev mode: inject hot-reload script before </body>.
     var owned_body: ?[]u8 = null;
@@ -176,7 +220,7 @@ fn sendResponse(std_req: *std.http.Server.Request, response: anytype) !void {
     var header_buf: [2048]u8 = undefined;
     var bw = try std_req.respondStreaming(&header_buf, .{
         .respond_options = .{
-            .status = response.status,
+            .status        = response.status,
             .extra_headers = &(ct_header ++ security_headers),
         },
     });
@@ -195,7 +239,6 @@ const hot_reload_script =
 ;
 
 /// Serve a pre-rendered HTML file from dist/ if it exists.
-/// Maps: "/" → "dist/index.html", "/about" → "dist/about.html"
 fn tryServePrerendered(
     alloc: std.mem.Allocator,
     std_req: *std.http.Server.Request,
@@ -218,7 +261,7 @@ fn tryServePrerendered(
     var header_buf: [512]u8 = undefined;
     var bw = std_req.respondStreaming(&header_buf, .{
         .respond_options = .{
-            .status = .ok,
+            .status        = .ok,
             .extra_headers = &.{
                 .{ .name = "content-type", .value = "text/html; charset=utf-8" },
             },
@@ -234,6 +277,6 @@ fn injectHotReload(alloc: std.mem.Allocator, body: []const u8) ![]u8 {
     const marker = "</body>";
     const idx = std.mem.lastIndexOf(u8, body, marker) orelse return error.NoBodyTag;
     const before = body[0..idx];
-    const after = body[idx + marker.len ..];
+    const after  = body[idx + marker.len ..];
     return std.fmt.allocPrint(alloc, "{s}{s}{s}", .{ before, hot_reload_script, after });
 }


### PR DESCRIPTION
## Summary

- **`Request`**: new `query_string`, `body`, `cookies_raw` fields; `queryParam(name)`, `queryParams()`, `cookie(name)` methods — all with unit tests
- **`Response`**: `redirect(location, status)` helper + `.redirect` ContentType sentinel so the server emits a proper `Location` header
- **`server.zig`**: splits `raw_target` into path + query string, reads `Cookie` header, reads request body up to 4 MiB, handles redirect responses
- **`mer.zig`**: exports `redirect`, `parseJson(T, req)`, and `badRequest(msg)` at the top level

## Test plan

- [x] `zig build test` passes (7 unit tests for queryParam + cookie helpers)
- [ ] Manual: `req.queryParam("page")` returns value from `?page=2`
- [ ] Manual: `mer.redirect("/login", .found)` returns 302 with `Location` header
- [ ] Manual: `req.cookie("session")` extracts value from `Cookie` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)