### PR TITLE
feat: kuri browser automation sidecar for debug mode

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,6 +13,12 @@ pub fn build(b: *std.Build) void {
     const dhi_model_mod = dhi_dep.module("model");
     const dhi_validator_mod = dhi_dep.module("validator");
 
+    // ── kuri dependency (browser automation for debug mode) ─────────────────
+    const kuri_dep = b.dependency("kuri", .{
+        .target = target,
+        .optimize = if (optimize != .Debug) optimize else .ReleaseFast,
+    });
+
     // ── "mer" module (framework public API) ──────────────────────────────────
     const mer_mod = b.addModule("mer", .{
         .root_source_file = b.path("src/mer.zig"),
@@ -39,6 +45,10 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{ .name = "merjs", .root_module = main_mod });
     b.installArtifact(exe);
+
+    // Install kuri binary alongside merjs.
+    const install_kuri = b.addInstallArtifact(kuri_dep.artifact("kuri"), .{});
+    b.getInstallStep().dependOn(&install_kuri.step);
 
     // ── `zig build serve` ────────────────────────────────────────────────────
     const run_exe = b.addRunArtifact(exe);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,6 +8,10 @@
             .url = "git+https://github.com/justrach/dhi.git#20bbf6a25e9f0d28bd915f6dc7e18a9766b1134a",
             .hash = "dhi-0.1.0-Fz3bn3g6AwCFCeeGWyrLnJo-V95C5VkFxdVaWMEqc7iy",
         },
+        .kuri = .{
+            .url = "git+https://github.com/justrach/kuri.git#81baa2ffb060f87d2e8f6de2aa69eb509c700b91",
+            .hash = "agentic_browdie-0.1.0-uVYLKYovCADlIJw6TDdL9NnVr-LAtCLt5Sz4o1e8l6Y2",
+        },
     },
     .paths = .{
         "build.zig",

--- a/src/dev.zig
+++ b/src/dev.zig
@@ -149,6 +149,7 @@ pub fn serveDebug(
         try w.writeAll("<li>Use <code>std.log.scoped(.mypage)</code> in page handlers for route-level logs</li>");
         try w.writeAll("<li><code>/_mer/events</code> — SSE hot reload stream</li>");
         try w.writeAll("<li>Append <code>?format=json</code> to this URL for machine-readable output</li>");
+        try w.writeAll("<li>Run with <code>--debug</code> to enable kuri browser automation at <code>/_mer/kuri/</code></li>");
         try w.writeAll("</ul>");
 
         try w.writeAll("</body></html>");

--- a/src/kuri.zig
+++ b/src/kuri.zig
@@ -1,0 +1,226 @@
+// kuri.zig — kuri browser automation sidecar for debug mode.
+// Spawns Chrome + kuri and proxies /_mer/kuri/* requests to kuri's HTTP API.
+
+const std = @import("std");
+const c = @cImport(@cInclude("stdlib.h"));
+const log = std.log.scoped(.kuri);
+pub const default_port: u16 = 9222;
+
+pub const Kuri = struct {
+    child: ?std.process.Child,
+    chrome: ?std.process.Child,
+    port: u16,
+    app_port: u16,
+    allocator: std.mem.Allocator,
+
+    const cdp_port: u16 = 9223;
+
+    pub fn spawn(allocator: std.mem.Allocator, app_port: u16, kuri_port: u16) Kuri {
+        var self = Kuri{
+            .child = null,
+            .chrome = null,
+            .port = kuri_port,
+            .app_port = app_port,
+            .allocator = allocator,
+        };
+
+        const kuri_bin = findKuriBinary(allocator) orelse {
+            log.warn("kuri binary not found — debug browser automation disabled", .{});
+            log.warn("install: curl -fsSL https://raw.githubusercontent.com/justrach/kuri/main/install.sh | sh", .{});
+            return self;
+        };
+        defer allocator.free(kuri_bin);
+
+        // Launch headless Chrome with a known CDP port.
+        self.chrome = launchChrome(allocator, cdp_port);
+        if (self.chrome == null) {
+            log.warn("Chrome not found — debug browser automation disabled", .{});
+            return self;
+        }
+        std.Thread.sleep(1 * std.time.ns_per_s);
+
+        // Set env vars for kuri — needs null-terminated strings for C setenv.
+        var port_z: [8:0]u8 = .{0} ** 8;
+        _ = std.fmt.bufPrint(&port_z, "{d}", .{kuri_port}) catch return self;
+        var cdp_z: [64:0]u8 = .{0} ** 64;
+        _ = std.fmt.bufPrint(&cdp_z, "ws://127.0.0.1:{d}", .{cdp_port}) catch return self;
+
+        _ = c.setenv("PORT", &port_z, 1);
+        _ = c.setenv("HOST", "127.0.0.1", 1);
+        _ = c.setenv("CDP_URL", &cdp_z, 1);
+        _ = c.setenv("HEADLESS", "true", 1);
+
+        var child = std.process.Child.init(&.{kuri_bin}, allocator);
+        child.stdout_behavior = .Pipe;
+        child.stderr_behavior = .Pipe;
+
+        child.spawn() catch |err| {
+            log.warn("failed to spawn kuri: {} — debug browser automation disabled", .{err});
+            clearEnv();
+            return self;
+        };
+
+        clearEnv();
+        self.child = child;
+
+        log.info("kuri started on :{d} — browser automation active", .{kuri_port});
+        log.info("  snapshot:   /_mer/kuri/snapshot", .{});
+        log.info("  screenshot: /_mer/kuri/screenshot", .{});
+        log.info("  navigate:   /_mer/kuri/navigate?url=/your-page", .{});
+        log.info("  dashboard:  /_mer/kuri/", .{});
+        return self;
+    }
+
+    pub fn deinit(self: *Kuri) void {
+        if (self.child) |*child| {
+            _ = child.kill() catch {};
+            _ = child.wait() catch {};
+        }
+        self.child = null;
+        if (self.chrome) |*chrome| {
+            _ = chrome.kill() catch {};
+            _ = chrome.wait() catch {};
+        }
+        self.chrome = null;
+    }
+
+    pub fn isRunning(self: *const Kuri) bool {
+        return self.child != null;
+    }
+
+    /// Proxy a request to the kuri sidecar.
+    pub fn proxyRequest(
+        self: *const Kuri,
+        alloc: std.mem.Allocator,
+        std_req: *std.http.Server.Request,
+        raw_target: []const u8,
+    ) !void {
+        const kuri_path = if (std.mem.startsWith(u8, raw_target, "/_mer/kuri"))
+            raw_target["/_mer/kuri".len..]
+        else
+            raw_target;
+
+        const target = if (kuri_path.len == 0 or std.mem.eql(u8, kuri_path, "/"))
+            "/health"
+        else
+            kuri_path;
+
+        var url_buf: [2048]u8 = undefined;
+        const url = std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}{s}", .{ self.port, target }) catch {
+            try sendKuriError(std_req, "URL too long");
+            return;
+        };
+
+        var client = std.http.Client{ .allocator = alloc };
+        defer client.deinit();
+
+        var collecting: std.io.Writer.Allocating = .init(alloc);
+        defer collecting.deinit();
+
+        _ = client.fetch(.{
+            .location = .{ .url = url },
+            .response_writer = &collecting.writer,
+        }) catch {
+            try sendKuriError(std_req, "kuri is not responding — is it running?");
+            return;
+        };
+
+        const body = if (collecting.writer.end > 0)
+            collecting.writer.buffer[0..collecting.writer.end]
+        else
+            "{\"status\":\"ok\"}";
+
+        const fixed = [_]std.http.Header{
+            .{ .name = "content-type", .value = "application/json" },
+            .{ .name = "access-control-allow-origin", .value = "*" },
+        };
+        std_req.respond(body, .{ .extra_headers = &fixed }) catch {};
+    }
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn setEnv(name: [*:0]const u8, value: [*:0]const u8) void {
+    _ = c.setenv(name, value, 1);
+}
+
+fn clearEnv() void {
+    _ = c.unsetenv("PORT");
+    _ = c.unsetenv("CDP_URL");
+}
+
+fn sendKuriError(std_req: *std.http.Server.Request, msg: []const u8) !void {
+    var buf: [256]u8 = undefined;
+    const body = std.fmt.bufPrint(&buf, "{{\"error\":\"{s}\"}}", .{msg}) catch msg;
+    const fixed = [_]std.http.Header{
+        .{ .name = "content-type", .value = "application/json" },
+    };
+    std_req.respond(body, .{
+        .status = .service_unavailable,
+        .extra_headers = &fixed,
+    }) catch {};
+}
+
+fn launchChrome(allocator: std.mem.Allocator, port: u16) ?std.process.Child {
+    const chrome_paths = [_][]const u8{
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        "google-chrome",
+        "chromium",
+    };
+
+    var port_buf: [32]u8 = undefined;
+    const port_arg = std.fmt.bufPrint(&port_buf, "--remote-debugging-port={d}", .{port}) catch return null;
+
+    for (chrome_paths) |chrome_path| {
+        var child = std.process.Child.init(
+            &.{ chrome_path, "--headless", "--disable-gpu", "--no-sandbox", "--incognito", port_arg, "about:blank" },
+            allocator,
+        );
+        child.stdout_behavior = .Pipe;
+        child.stderr_behavior = .Pipe;
+        child.spawn() catch continue;
+        log.info("Chrome launched (headless) on CDP port {d}", .{port});
+        return child;
+    }
+    return null;
+}
+
+fn findKuriBinary(allocator: std.mem.Allocator) ?[]const u8 {
+    // 1. Check alongside our own executable (zig-out/bin/kuri).
+    if (std.fs.selfExePath(&self_exe_buf)) |self_path| {
+        const dir = std.fs.path.dirname(self_path) orelse ".";
+        if (std.fmt.allocPrint(allocator, "{s}/kuri", .{dir})) |s| {
+            std.fs.cwd().access(s, .{}) catch {
+                allocator.free(s);
+                return findKuriFallback(allocator);
+            };
+            return s;
+        } else |_| {}
+    } else |_| {}
+    return findKuriFallback(allocator);
+}
+
+var self_exe_buf: [std.fs.max_path_bytes]u8 = undefined;
+
+fn findKuriFallback(allocator: std.mem.Allocator) ?[]const u8 {
+    const result = std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "which", "kuri" },
+    }) catch return null;
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    if (result.term == .Exited and result.term.Exited == 0 and result.stdout.len > 0) {
+        const trimmed = std.mem.trimRight(u8, result.stdout, "\n\r ");
+        return allocator.dupe(u8, trimmed) catch null;
+    }
+
+    const home = std.process.getEnvVarOwned(allocator, "HOME") catch return null;
+    defer allocator.free(home);
+    const home_bin = std.fmt.allocPrint(allocator, "{s}/.local/bin/kuri", .{home}) catch return null;
+    std.fs.cwd().access(home_bin, .{}) catch {
+        allocator.free(home_bin);
+        return null;
+    };
+    return home_bin;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,6 +42,11 @@ pub fn main() !void {
             i += 1;
         } else if (std.mem.eql(u8, args[i], "--no-dev")) {
             config.dev = false;
+        } else if (std.mem.eql(u8, args[i], "--debug")) {
+            config.debug = true;
+        } else if (std.mem.eql(u8, args[i], "--kuri-port") and i + 1 < args.len) {
+            config.kuri_port = try std.fmt.parseInt(u16, args[i + 1], 10);
+            i += 1;
         } else if (std.mem.eql(u8, args[i], "--verbose") or std.mem.eql(u8, args[i], "-v")) {
             config.verbose = true;
         } else if (std.mem.eql(u8, args[i], "--prerender")) {

--- a/src/server.zig
+++ b/src/server.zig
@@ -7,6 +7,7 @@ const Router = @import("router.zig").Router;
 const dispatch_mod = @import("dispatch.zig");
 const static = @import("static.zig");
 const watcher_mod = @import("watcher.zig");
+const kuri_mod = @import("kuri.zig");
 const telemetry = mer.telemetry;
 const dev_mod = mer.dev;
 
@@ -28,12 +29,15 @@ pub const Config = struct {
     port: u16 = 3000,
     dev: bool = false,
     verbose: bool = false,
+    debug: bool = false,
+    kuri_port: u16 = 9222,
 };
 
 pub const Server = struct {
     config: Config,
     router: *const Router,
     watcher: ?*watcher_mod.Watcher,
+    kuri: ?kuri_mod.Kuri,
     allocator: std.mem.Allocator,
     pool: std.Thread.Pool,
 
@@ -48,6 +52,7 @@ pub const Server = struct {
             .config = config,
             .router = router,
             .watcher = watcher,
+            .kuri = null,
             .pool = undefined,
         };
     }
@@ -61,6 +66,12 @@ pub const Server = struct {
 
         // Init static file cache.
         static.initCache(self.allocator);
+
+        // Spawn kuri sidecar in debug mode.
+        if (self.config.debug) {
+            self.kuri = kuri_mod.Kuri.spawn(self.allocator, self.config.port, self.config.kuri_port);
+        }
+        defer if (self.kuri) |*k| k.deinit();
 
         const addr = try std.net.Address.parseIp(self.config.host, self.config.port);
         var net_server = try addr.listen(.{ .reuse_address = true, .kernel_backlog = 512 });
@@ -81,6 +92,7 @@ pub const Server = struct {
                 .conn = conn,
                 .router = self.router,
                 .watcher = self.watcher,
+                .kuri = if (self.kuri) |*k| k else null,
                 .allocator = self.allocator,
                 .dev = self.config.dev,
                 .verbose = self.config.verbose,
@@ -97,6 +109,7 @@ const ConnCtx = struct {
     conn: std.net.Server.Connection,
     router: *const Router,
     watcher: ?*watcher_mod.Watcher,
+    kuri: ?*kuri_mod.Kuri,
     allocator: std.mem.Allocator,
     dev: bool,
     verbose: bool,
@@ -125,7 +138,7 @@ fn handleConn(ctx: *ConnCtx) void {
         };
 
         const start = std.time.nanoTimestamp();
-        serveRequest(alloc, &std_req, ctx.router, ctx.watcher, ctx.dev, ctx.verbose) catch |err| {
+        serveRequest(alloc, &std_req, ctx.router, ctx.watcher, ctx.kuri, ctx.dev, ctx.verbose) catch |err| {
             log.err("serveRequest: {}", .{err});
             if (ctx.dev) {
                 dev_mod.sendErrorOverlay(&std_req, std_req.head.target, err, mer.version) catch {};
@@ -161,6 +174,7 @@ fn serveRequest(
     std_req: *std.http.Server.Request,
     router: *const Router,
     watcher: ?*watcher_mod.Watcher,
+    kuri: ?*const kuri_mod.Kuri,
     dev: bool,
     verbose: bool,
 ) !void {
@@ -194,6 +208,16 @@ fn serveRequest(
         const response = try dev_mod.serveDebug(alloc, route_infos, router.exact_map.count(), router.dynamic_routes.len, query_string, mer.version);
         try sendResponse(std_req, response);
         return;
+    }
+
+    // Kuri browser automation proxy (debug mode).
+    if (dev and std.mem.startsWith(u8, path, "/_mer/kuri")) {
+        if (kuri) |k| {
+            k.proxyRequest(alloc, std_req, raw_target) catch |err| {
+                log.err("kuri proxy: {}", .{err});
+            };
+            return;
+        }
     }
 
     // Static files from public/.


### PR DESCRIPTION
## Summary
- Add kuri (browser automation) as an optional debug-mode sidecar
- When `--debug` is passed, merjs spawns headless Chrome + kuri and proxies `/_mer/kuri/*` requests to kuri's HTTP API
- New `src/kuri.zig`: Chrome launcher, kuri spawner, HTTP proxy
- Add `--debug` and `--kuri-port` CLI flags
- Add kuri help text to `/_mer/debug` endpoint

## Test plan
- [x] `zig build` passes with kuri dependency
- [ ] Manual: `zig build serve -- --debug` spawns kuri sidecar
- [ ] Manual: `/_mer/kuri/health` returns JSON response