### PR TITLE
fix: unblock starter scaffold and release install flow

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -84,15 +84,15 @@ jobs:
           | macOS Apple Silicon | \`mer-macos-aarch64\` | $(du -h release/mer-macos-aarch64 | cut -f1) |
           | macOS Intel | \`mer-macos-x86_64\` | $(du -h release/mer-macos-x86_64 | cut -f1) |
           | Linux x86_64 | \`mer-linux-x86_64\` | $(du -h release/mer-linux-x86_64 | cut -f1) |
-          | Linux ARM64 | \`mer-linux-aarch64\` | $(du -h release/mer-linux-aarch64 | cut -f1) |
+           | Linux ARM64 | \`mer-linux-aarch64\` | $(du -h release/mer-linux-aarch64 | cut -f1) |
 
-          ### Install
-          \`\`\`bash
-          curl -L https://github.com/justrach/merjs/releases/download/${{ steps.version.outputs.tag }}/mer-linux-x86_64 -o mer
-          chmod +x mer && sudo mv mer /usr/local/bin/
-          \`\`\`
+           ### Install
+           \`\`\`bash
+          curl -fsSL https://raw.githubusercontent.com/justrach/merjs/main/scripts/install-mer.sh | \
+            MER_INSTALL_VERSION=${{ steps.version.outputs.tag }} sh
+           \`\`\`
 
-          > ⚠️ This is a pre-release beta build. Use stable releases for production.
+           > ⚠️ This is a pre-release beta build. Use stable releases for production.
           EOF
           )"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,18 @@ jobs:
         working-directory: release
         run: sha256sum mer-* > checksums.txt
 
+      - name: Write release notes
+        run: |
+          cat > release/notes.md <<'EOF'
+          ## Install
+
+          ```bash
+          curl -fsSL https://raw.githubusercontent.com/justrach/merjs/main/scripts/install-mer.sh | sh
+          ```
+
+          Manual install: download the matching `mer-*` binary below, rename it to `mer`, then place it on your `PATH`.
+          EOF
+
       - name: Create release
         run: |
           gh release create "${{ github.ref_name }}" \
@@ -52,7 +64,8 @@ jobs:
             release/mer-linux-x86_64 \
             release/mer-linux-aarch64 \
             release/checksums.txt \
+            --notes-file release/notes.md \
             --title "${{ github.ref_name }}" \
-            --generate-notes
+            --latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,13 @@ merjs is exploring whether you can get the full Next.js developer experience —
 
 ### Option A: `mer` CLI (recommended)
 
-Download the `mer` binary from [releases](https://github.com/justrach/merjs/releases/latest), then:
+Install the latest `mer` binary from [releases](https://github.com/justrach/merjs/releases/latest):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/justrach/merjs/main/scripts/install-mer.sh | sh
+```
+
+Or download a platform binary manually from the release page, then:
 
 ```bash
 mer init my-app
@@ -192,6 +198,23 @@ Or build from source:
 ```bash
 zig build cli -Doptimize=ReleaseSmall   # → zig-out/bin/mer
 ```
+
+Quick install from source checkout:
+
+```bash
+zig build cli -Doptimize=ReleaseSmall
+install -m 755 zig-out/bin/mer /usr/local/bin/mer
+```
+
+If you use merjs as a Zig dependency, prefer its exported API instead of reaching into package paths directly:
+
+```zig
+const merjs_dep = b.dependency("merjs", .{});
+const mer_mod = merjs_dep.module("mer");
+const server_mod = merjs_dep.module("server");
+```
+
+Fresh `mer init` apps also vendor their own `tools/codegen.zig`, so route generation no longer depends on internal merjs package paths.
 ---
 
 ## Demo

--- a/build.zig
+++ b/build.zig
@@ -124,6 +124,12 @@ pub fn build(b: *std.Build) void {
     b.step("grep", "Compile grep WASM").dependOn(&install_grep.step);
 
     // ── Worker WASM ─────────────────────────────────────────────────────────
+    const worker_named = b.addModule("worker", .{
+        .root_source_file = b.path("src/worker.zig"),
+        .target = wasm_target,
+        .optimize = .ReleaseSmall,
+    });
+    worker_named.addImport("mer", mer_mod);
     const worker_mod = b.createModule(.{
         .root_source_file = b.path("src/worker.zig"),
         .target = wasm_target,
@@ -184,6 +190,14 @@ pub fn build(b: *std.Build) void {
         });
         test_step.dependOn(&b.addRunArtifact(b.addTest(.{ .root_module = file_test_mod })).step);
     }
+    {
+        const cli_test_mod = b.createModule(.{
+            .root_source_file = b.path("cli.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+        test_step.dependOn(&b.addRunArtifact(b.addTest(.{ .root_module = cli_test_mod })).step);
+    }
     // Run router + runtime inline tests (through mer.zig as root to avoid
     // file-ownership conflict: mer.zig file-imports router.zig/server.zig/etc.,
     // so those files belong to the mer module and can't also be test roots).
@@ -230,6 +244,52 @@ pub fn build(b: *std.Build) void {
         }
         consumer_test_mod.addImport("routes", consumer_routes_mod);
         test_step.dependOn(&b.addRunArtifact(b.addTest(.{ .root_module = consumer_test_mod })).step);
+    }
+
+    // ── Starter scaffold smoke test ──────────────────────────────────────────
+    // Compiles the embedded starter templates that `mer init` writes so
+    // scaffold regressions fail in CI before they ship.
+    {
+        const starter_test_mod = b.createModule(.{
+            .root_source_file = b.path("tests/starter/src/test_starter_scaffold.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+        starter_test_mod.addImport("mer", mer_mod);
+
+        const starter_layout_mod = b.createModule(.{
+            .root_source_file = b.path("examples/starter/app/layout.zig"),
+        });
+        starter_layout_mod.addImport("mer", mer_mod);
+
+        const starter_page_specs = [_]struct { []const u8, []const u8 }{
+            .{ "app/index", "examples/starter/app/index.zig" },
+            .{ "app/about", "examples/starter/app/about.zig" },
+            .{ "app/404", "examples/starter/app/404.zig" },
+        };
+        const starter_routes_mod = b.createModule(.{
+            .root_source_file = b.path("tests/starter/src/routes.zig"),
+        });
+        starter_routes_mod.addImport("mer", mer_mod);
+        starter_routes_mod.addImport("app/layout", starter_layout_mod);
+
+        for (starter_page_specs) |page| {
+            const page_mod = b.createModule(.{ .root_source_file = b.path(page[1]) });
+            page_mod.addImport("mer", mer_mod);
+            page_mod.addImport("app/layout", starter_layout_mod);
+            starter_routes_mod.addImport(page[0], page_mod);
+            starter_test_mod.addImport(page[0], page_mod);
+        }
+
+        const starter_api_mod = b.createModule(.{
+            .root_source_file = b.path("examples/starter/api/hello.zig"),
+        });
+        starter_api_mod.addImport("mer", mer_mod);
+        starter_routes_mod.addImport("api/hello", starter_api_mod);
+        starter_test_mod.addImport("api/hello", starter_api_mod);
+        starter_test_mod.addImport("app/layout", starter_layout_mod);
+        starter_test_mod.addImport("routes", starter_routes_mod);
+        test_step.dependOn(&b.addRunArtifact(b.addTest(.{ .root_module = starter_test_mod })).step);
     }
 
     // ── Packages ────────────────────────────────────────────────────────────

--- a/cli.zig
+++ b/cli.zig
@@ -87,6 +87,7 @@ const template_files = [_]TemplateFile{
     .{ .path = "app/404.zig", .content = @embedFile("examples/starter/app/404.zig") },
     .{ .path = "api/hello.zig", .content = @embedFile("examples/starter/api/hello.zig") },
     .{ .path = "public/.gitkeep", .content = "" },
+    .{ .path = "tools/codegen.zig", .content = @embedFile("tools/codegen.zig") },
 };
 
 const build_zig_template =
@@ -117,7 +118,7 @@ const build_zig_template =
     \\    const codegen_exe = b.addExecutable(.{
     \\        .name = "codegen",
     \\        .root_module = b.createModule(.{
-    \\            .root_source_file = merjs_dep.path("tools/codegen.zig"),
+    \\            .root_source_file = b.path("tools/codegen.zig"),
     \\            .target = b.graph.host,
     \\            .optimize = .Debug,
     \\        }),
@@ -134,6 +135,20 @@ const build_zig_template =
     \\    run_exe.step.dependOn(b.getInstallStep());
     \\    if (b.args) |args| run_exe.addArgs(args);
     \\    b.step("serve", "Start the dev server").dependOn(&run_exe.step);
+    \\
+    \\    // zig build test
+    \\    const test_mod = b.createModule(.{
+    \\        .root_source_file = b.path("src/main.zig"),
+    \\        .target = target,
+    \\        .optimize = optimize,
+    \\    });
+    \\    test_mod.addImport("mer", mer_mod);
+    \\    addDirModules(b, test_mod, mer_mod, "app");
+    \\    addDirModules(b, test_mod, mer_mod, "api");
+    \\    addRoutesModule(b, test_mod, mer_mod);
+    \\    const run_tests = b.addRunArtifact(b.addTest(.{ .root_module = test_mod }));
+    \\    run_tests.step.dependOn(&run_codegen.step);
+    \\    b.step("test", "Compile the starter app").dependOn(&run_tests.step);
     \\}
     \\
     \\fn addRoutesModule(b: *std.Build, mod: *std.Build.Module, mer_mod: *std.Build.Module) void {
@@ -253,6 +268,98 @@ const main_zig_template =
     \\
 ;
 
+const generated_routes_placeholder =
+    \\// GENERATED — do not edit by hand.
+    \\// Re-run `zig build codegen` to regenerate.
+    \\
+    \\const Route = @import("mer").Route;
+    \\
+    \\pub const routes: []const Route = &.{};
+    \\pub const layout = null;
+    \\pub const streamLayout = null;
+    \\pub const notFound = null;
+    \\
+;
+
+fn writeScaffoldFile(dir: std.fs.Dir, path: []const u8, content: []const u8) !void {
+    if (std.fs.path.dirname(path)) |parent| {
+        dir.makePath(parent) catch {};
+    }
+    const file = try dir.createFile(path, .{});
+    defer file.close();
+    try file.writeAll(content);
+}
+
+fn writeTemplateFiles(dir: std.fs.Dir) !void {
+    for (template_files) |tf| {
+        try writeScaffoldFile(dir, tf.path, tf.content);
+    }
+}
+
+fn projectNameForZon(alloc: std.mem.Allocator, name: []const u8) ![]u8 {
+    const source = blk: {
+        if (std.mem.eql(u8, name, ".")) {
+            const cwd = try std.process.getCwdAlloc(alloc);
+            defer alloc.free(cwd);
+            break :blk try alloc.dupe(u8, std.fs.path.basename(cwd));
+        }
+        break :blk try alloc.dupe(u8, std.fs.path.basename(name));
+    };
+    defer alloc.free(source);
+
+    var out = std.ArrayList(u8){};
+    defer out.deinit(alloc);
+
+    for (source) |c| {
+        if (out.items.len == 32) break;
+        try out.append(alloc, if (std.ascii.isAlphanumeric(c) or c == '_') c else '_');
+    }
+
+    if (out.items.len == 0) {
+        try out.appendSlice(alloc, "app");
+    }
+
+    if (!std.ascii.isAlphabetic(out.items[0]) and out.items[0] != '_') {
+        if (out.items.len == 32) {
+            out.items[0] = '_';
+        } else {
+            try out.insert(alloc, 0, '_');
+        }
+    }
+
+    return out.toOwnedSlice(alloc);
+}
+
+fn writeBuildZigZon(dir: std.fs.Dir, alloc: std.mem.Allocator, name: []const u8) !void {
+    const zig_name = try projectNameForZon(alloc, name);
+    defer alloc.free(zig_name);
+
+    const file = try dir.createFile("build.zig.zon", .{});
+    defer file.close();
+    try file.writeAll(".{\n    .name = .");
+    try file.writeAll(zig_name);
+    try file.writeAll(
+        \\,
+        \\    .version = "0.1.0",
+        \\    .minimum_zig_version = "0.15.1",
+        \\    .dependencies = .{
+        \\        .merjs = .{
+        \\            .url = "git+https://github.com/justrach/merjs.git",
+        \\        },
+        \\    },
+        \\    .paths = .{
+        \\        "build.zig",
+        \\        "build.zig.zon",
+        \\        "src",
+        \\        "app",
+        \\        "api",
+        \\        "public",
+        \\    },
+        \\}
+        \\
+    );
+}
+
 fn cmdInit(alloc: std.mem.Allocator, name: []const u8) !void {
     const use_cwd = std.mem.eql(u8, name, ".");
     if (!use_cwd) {
@@ -271,14 +378,7 @@ fn cmdInit(alloc: std.mem.Allocator, name: []const u8) !void {
         try std.fs.cwd().openDir(name, .{});
 
     // Write template files.
-    for (template_files) |tf| {
-        if (std.fs.path.dirname(tf.path)) |parent| {
-            dir.makePath(parent) catch {};
-        }
-        const file = try dir.createFile(tf.path, .{});
-        defer file.close();
-        try file.writeAll(tf.content);
-    }
+    try writeTemplateFiles(dir);
 
     // Write build.zig.
     {
@@ -288,38 +388,7 @@ fn cmdInit(alloc: std.mem.Allocator, name: []const u8) !void {
     }
 
     // Write build.zig.zon.
-    // Sanitize project name to a valid Zig bare identifier (replace non-alnum with _).
-    const zig_name = try alloc.dupe(u8, name);
-    defer alloc.free(zig_name);
-    for (zig_name) |*c| {
-        if (!std.ascii.isAlphanumeric(c.*) and c.* != '_') c.* = '_';
-    }
-    {
-        const file = try dir.createFile("build.zig.zon", .{});
-        defer file.close();
-        try file.writeAll(".{\n    .name = .");
-        try file.writeAll(zig_name);
-        try file.writeAll(
-            \\,
-            \\    .version = "0.1.0",
-            \\    .minimum_zig_version = "0.15.1",
-            \\    .dependencies = .{
-            \\        .merjs = .{
-            \\            .url = "git+https://github.com/justrach/merjs.git",
-            \\        },
-            \\    },
-            \\    .paths = .{
-            \\        "build.zig",
-            \\        "build.zig.zon",
-            \\        "src",
-            \\        "app",
-            \\        "api",
-            \\        "public",
-            \\    },
-            \\}
-            \\
-        );
-    }
+    try writeBuildZigZon(dir, alloc, name);
 
     // Patch in the fingerprint: run zig build to get the suggested value.
     {
@@ -433,6 +502,11 @@ fn cmdInit(alloc: std.mem.Allocator, name: []const u8) !void {
         file.close();
     }
     {
+        const file = try dir.createFile("src/generated/routes.zig", .{});
+        defer file.close();
+        try file.writeAll(generated_routes_placeholder);
+    }
+    {
         const file = try dir.createFile("src/main.zig", .{});
         defer file.close();
         try file.writeAll(main_zig_template);
@@ -458,13 +532,83 @@ fn cmdInit(alloc: std.mem.Allocator, name: []const u8) !void {
 
     print("\n", .{});
     print("  mer project created", .{});
-    if (!use_cwd) print(" in ./{s}", .{name});
+    if (!use_cwd) {
+        if (std.fs.path.isAbsolute(name)) {
+            print(" in {s}", .{name});
+        } else {
+            print(" in ./{s}", .{name});
+        }
+    }
     print("\n\n", .{});
     print("  next steps:\n\n", .{});
     if (!use_cwd) print("    cd {s}\n", .{name});
     print("    zig build serve       # start dev server on :3000\n", .{});
     print("\n  or just: mer dev\n", .{});
     print("\n  optional: mer add css | wasm | worker\n\n", .{});
+}
+
+test "projectNameForZon uses basename for absolute paths" {
+    const alloc = std.testing.allocator;
+    const got = try projectNameForZon(alloc, "/tmp/nested/my-app");
+    defer alloc.free(got);
+    try std.testing.expectEqualStrings("my_app", got);
+}
+
+test "projectNameForZon prefixes numeric names" {
+    const alloc = std.testing.allocator;
+    const got = try projectNameForZon(alloc, "123site");
+    defer alloc.free(got);
+    try std.testing.expectEqualStrings("_123site", got);
+}
+
+test "projectNameForZon clamps long names to 32 chars" {
+    const alloc = std.testing.allocator;
+    const got = try projectNameForZon(alloc, "abcdefghijklmnopqrstuvwxyz0123456789");
+    defer alloc.free(got);
+    try std.testing.expectEqual(@as(usize, 32), got.len);
+    try std.testing.expectEqualStrings("abcdefghijklmnopqrstuvwxyz012345", got);
+}
+
+test "build_zig_template exposes a starter test step" {
+    try std.testing.expect(std.mem.indexOf(u8, build_zig_template, "b.step(\"test\", \"Compile the starter app\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, build_zig_template, "run_tests.step.dependOn(&run_codegen.step);") != null);
+}
+
+test "build_zig_template uses local codegen entrypoint" {
+    try std.testing.expect(std.mem.indexOf(u8, build_zig_template, "b.path(\"tools/codegen.zig\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, build_zig_template, "merjs_dep.path(\"tools/codegen.zig\")") == null);
+}
+
+test "writeBuildZigZon uses sanitized basename for absolute paths" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeBuildZigZon(tmp.dir, std.testing.allocator, "/tmp/nested/my-app");
+    const content = try tmp.dir.readFileAlloc(std.testing.allocator, "build.zig.zon", 4096);
+    defer std.testing.allocator.free(content);
+
+    try std.testing.expect(std.mem.indexOf(u8, content, ".name = .my_app") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\"public\"") != null);
+}
+
+test "writeTemplateFiles emits starter scaffold files" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTemplateFiles(tmp.dir);
+
+    try tmp.dir.access("app/index.zig", .{});
+    try tmp.dir.access("app/about.zig", .{});
+    try tmp.dir.access("app/layout.zig", .{});
+    try tmp.dir.access("app/404.zig", .{});
+    try tmp.dir.access("api/hello.zig", .{});
+    try tmp.dir.access("public/.gitkeep", .{});
+    try tmp.dir.access("tools/codegen.zig", .{});
+}
+
+test "generated routes placeholder is valid scaffold output" {
+    try std.testing.expect(std.mem.indexOf(u8, generated_routes_placeholder, "pub const routes: []const Route = &.{};") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_routes_placeholder, "pub const notFound = null;") != null);
 }
 
 // ── dev ─────────────────────────────────────────────────────────────────────

--- a/examples/site/app/counter.zig
+++ b/examples/site/app/counter.zig
@@ -43,7 +43,11 @@ fn page() h.Node {
             h.button(.{ .id = "btn-reset", .class = "btn btn-reset", .type = "button" }, "reset"),
             h.button(.{ .id = "btn-inc", .class = "btn btn-inc", .type = "button" }, "+"),
         }),
-        h.span(.{ .class = "badge" }, "wasm32-freestanding"),
+        h.div(.{ .class = "runtime" }, .{
+            h.span(.{ .class = "badge" }, "wasm32-freestanding"),
+            h.span(.{ .id = "runtime-status", .class = "runtime-status runtime-pending" }, "Checking WASM..."),
+        }),
+        h.p(.{ .id = "runtime-note", .class = "runtime-note", .hidden = true }, ""),
         h.div(.{ .class = "config-note" }, .{
             h.raw("Bounds enforced at <strong>comptime</strong> via "),
             h.code(.{}, "counter_config.zig"),
@@ -61,12 +65,25 @@ fn comptimeIntStr(comptime val: i32) []const u8 {
 const counter_js =
     \\(async function(){
     \\  const display = document.getElementById('count-value');
+    \\  const status = document.getElementById('runtime-status');
+    \\  const note = document.getElementById('runtime-note');
 ++ std.fmt.comptimePrint(
     \\  const MIN={d}, MAX={d}, STEP={d}, INIT={d};
 , .{ cfg.min, cfg.max, cfg.step, cfg.initial }) ++
     \\  let count = INIT;
     \\  function clamp(v){ return Math.max(MIN, Math.min(MAX, v)); }
     \\  function sync(){ display.textContent = count; }
+    \\  function setMode(label, cls, message){
+    \\    status.textContent = label;
+    \\    status.className = 'runtime-status ' + cls;
+    \\    if(message){
+    \\      note.hidden = false;
+    \\      note.textContent = message;
+    \\    } else {
+    \\      note.hidden = true;
+    \\      note.textContent = '';
+    \\    }
+    \\  }
     \\  try {
     \\    const {instance} = await WebAssembly.instantiateStreaming(fetch('/counter.wasm'),{});
     \\    const w = instance.exports;
@@ -74,10 +91,15 @@ const counter_js =
     \\    document.getElementById('btn-dec').onclick = ()=>{ w.decrement(); display.textContent = w.get_count(); };
     \\    document.getElementById('btn-reset').onclick = ()=>{ w.reset(); display.textContent = w.get_count(); };
     \\    display.textContent = w.get_count();
+    \\    setMode('WASM active', 'runtime-ok', '');
     \\  } catch(e) {
     \\    document.getElementById('btn-inc').onclick = ()=>{ count = clamp(count + STEP); sync(); };
     \\    document.getElementById('btn-dec').onclick = ()=>{ count = clamp(count - STEP); sync(); };
     \\    document.getElementById('btn-reset').onclick = ()=>{ count = INIT; sync(); };
+    \\    sync();
+    \\    const reason = (e && e.message) ? e.message : 'WASM failed to initialize.';
+    \\    setMode('JS fallback', 'runtime-fallback', reason);
+    \\    console.warn('counter.wasm fallback:', e);
     \\  }
     \\})();
 ;
@@ -132,6 +154,19 @@ const page_css =
     \\  font-size:11px; color:var(--muted); background:var(--bg2);
     \\  border:1px solid var(--border); border-radius:100px;
     \\  padding:4px 12px; letter-spacing:0.04em;
+    \\}
+    \\.runtime {
+    \\  display:flex; align-items:center; gap:10px; flex-wrap:wrap; justify-content:center;
+    \\}
+    \\.runtime-status {
+    \\  font-size:11px; border-radius:100px; padding:4px 12px; letter-spacing:0.04em;
+    \\  border:1px solid var(--border);
+    \\}
+    \\.runtime-pending { color:var(--muted); background:var(--bg2); }
+    \\.runtime-ok { color:#17603a; background:#e5f5ea; border-color:#b6ddc4; }
+    \\.runtime-fallback { color:#8a3e12; background:#fff1e6; border-color:#f0c5a6; }
+    \\.runtime-note {
+    \\  max-width:420px; font-size:12px; line-height:1.5; color:var(--muted);
     \\}
     \\.config-note {
     \\  font-size:12px; color:var(--muted); max-width:360px; line-height:1.6;

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -1,6 +1,6 @@
 # merjs Starter Template
 
-This is the default template used by `create-mer-app`.
+This is the default template used by `mer init`.
 
 ## Structure
 
@@ -19,4 +19,5 @@ api/
 ```bash
 zig build codegen   # generate routes
 zig build serve     # start dev server on :3000
+zig build test      # compile the starter app
 ```

--- a/examples/starter/app/404.zig
+++ b/examples/starter/app/404.zig
@@ -73,30 +73,3 @@ const html =
     \\</body>
     \\</html>
 ;
-    \\    :root { --bg:#f0ebe3; --bg2:#e8e2d9; --bg3:#ddd5cc; --text:#252530; --muted:#8a7f78; --border:#d5cdc4; --red:#e8251f; }
-    \\    body { background:var(--bg); color:var(--text); font-family:'DM Sans',system-ui,sans-serif; min-height:100vh; display:flex; align-items:center; justify-content:center; }
-    \\    a { color:inherit; text-decoration:none; }
-    \\    .wrap { display:flex; flex-direction:column; align-items:center; gap:24px; text-align:center; padding:40px 24px; }
-    \\    .wordmark { font-family:'DM Serif Display',Georgia,serif; font-size:18px; letter-spacing:-0.02em; }
-    \\    .wordmark span { color:var(--red); }
-    \\    .code { font-family:'SF Mono','Fira Code',monospace; font-size:120px; font-weight:700; line-height:1; color:var(--bg3); letter-spacing:-0.04em; }
-    \\    h1 { font-family:'DM Serif Display',Georgia,serif; font-size:28px; letter-spacing:-0.02em; }
-    \\    .sub { font-size:14px; color:var(--muted); max-width:320px; line-height:1.6; }
-    \\    .back-btn { display:inline-flex; align-items:center; gap:6px; font-size:13px; color:var(--bg); background:var(--text); padding:10px 20px; border-radius:8px; transition:opacity 0.15s; }
-    \\    .back-btn:hover { opacity:0.85; }
-    \\    .path { font-family:'SF Mono',monospace; font-size:12px; color:var(--muted); background:var(--bg2); border:1px solid var(--border); border-radius:6px; padding:6px 14px; }
-    \\  </style>
-    \\</head>
-    \\<body>
-    \\<div class="wrap">
-    \\  <a href="/" class="wordmark">mer<span>js</span></a>
-    \\  <div class="code">404</div>
-    \\  <h1>Page not found</h1>
-    \\  <p class="sub">The route you're looking for doesn't exist. Maybe it was never here, or maybe it just hasn't been built yet.</p>
-    \\  <div class="path" id="path"></div>
-    \\  <a href="/" class="back-btn">← back to home</a>
-    \\</div>
-    \\<script>document.getElementById('path').textContent = location.pathname;</script>
-    \\</body>
-    \\</html>
-;

--- a/scripts/install-mer.sh
+++ b/scripts/install-mer.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+
+set -eu
+
+REPO="${MER_INSTALL_REPO:-justrach/merjs}"
+VERSION="${MER_INSTALL_VERSION:-latest}"
+
+need_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "install-mer: missing required command: $1" >&2
+        exit 1
+    fi
+}
+
+need_cmd uname
+need_cmd mktemp
+need_cmd chmod
+need_cmd mkdir
+need_cmd mv
+
+if command -v curl >/dev/null 2>&1; then
+    fetch() {
+        curl -fsSL "$1" -o "$2"
+    }
+elif command -v wget >/dev/null 2>&1; then
+    fetch() {
+        wget -qO "$2" "$1"
+    }
+else
+    echo "install-mer: need curl or wget to download releases" >&2
+    exit 1
+fi
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS" in
+    Darwin) os="macos" ;;
+    Linux) os="linux" ;;
+    *)
+        echo "install-mer: unsupported OS: $OS" >&2
+        exit 1
+        ;;
+esac
+
+case "$ARCH" in
+    arm64|aarch64) arch="aarch64" ;;
+    x86_64|amd64) arch="x86_64" ;;
+    *)
+        echo "install-mer: unsupported architecture: $ARCH" >&2
+        exit 1
+        ;;
+esac
+
+asset="mer-${os}-${arch}"
+base_url="https://github.com/${REPO}/releases"
+if [ "$VERSION" = "latest" ]; then
+    download_url="${base_url}/latest/download/${asset}"
+    checksums_url="${base_url}/latest/download/checksums.txt"
+else
+    download_url="${base_url}/download/${VERSION}/${asset}"
+    checksums_url="${base_url}/download/${VERSION}/checksums.txt"
+fi
+
+if [ -n "${MER_INSTALL_DIR:-}" ]; then
+    install_dir="$MER_INSTALL_DIR"
+elif [ -w /usr/local/bin ]; then
+    install_dir="/usr/local/bin"
+else
+    install_dir="${HOME}/.local/bin"
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+bin_path="${tmpdir}/mer"
+checksums_path="${tmpdir}/checksums.txt"
+
+echo "install-mer: downloading ${asset}" >&2
+fetch "$download_url" "$bin_path"
+fetch "$checksums_url" "$checksums_path"
+
+if command -v shasum >/dev/null 2>&1; then
+    (
+        cd "$tmpdir"
+        grep " ${asset}\$" "$checksums_path" | sed "s| ${asset}\$| mer|" | shasum -a 256 -c -
+    )
+elif command -v sha256sum >/dev/null 2>&1; then
+    (
+        cd "$tmpdir"
+        grep " ${asset}\$" "$checksums_path" | sed "s| ${asset}\$| mer|" | sha256sum -c -
+    )
+else
+    echo "install-mer: checksum tool not found, skipping verification" >&2
+fi
+
+mkdir -p "$install_dir"
+chmod +x "$bin_path"
+mv "$bin_path" "${install_dir}/mer"
+
+echo "install-mer: installed to ${install_dir}/mer" >&2
+case ":${PATH}:" in
+    *":${install_dir}:"*) ;;
+    *)
+        echo "install-mer: add ${install_dir} to PATH to run 'mer'" >&2
+        ;;
+esac

--- a/tests/starter/src/routes.zig
+++ b/tests/starter/src/routes.zig
@@ -1,0 +1,11 @@
+const Route = @import("mer").Route;
+
+const app_index = @import("app/index");
+const app_about = @import("app/about");
+const api_hello = @import("api/hello");
+
+pub const routes: []const Route = &.{
+    .{ .path = "/", .render = app_index.render, .render_stream = null, .meta = app_index.meta, .prerender = false },
+    .{ .path = "/about", .render = app_about.render, .render_stream = null, .meta = app_about.meta, .prerender = true },
+    .{ .path = "/api/hello", .render = api_hello.render, .render_stream = null, .meta = .{}, .prerender = false },
+};

--- a/tests/starter/src/test_starter_scaffold.zig
+++ b/tests/starter/src/test_starter_scaffold.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+const mer = @import("mer");
+const routes = @import("routes");
+const not_found = @import("app/404");
+
+test "starter scaffold routes compile and load" {
+    var router = mer.Router.fromGenerated(std.testing.allocator, routes);
+    defer router.deinit();
+
+    try std.testing.expectEqual(@as(usize, 3), router.routes.len);
+    try std.testing.expect(router.findRoute("/") != null);
+    try std.testing.expect(router.findRoute("/about") != null);
+    try std.testing.expect(router.findRoute("/api/hello") != null);
+}
+
+test "starter scaffold 404 template compiles" {
+    const resp = not_found.render(.{
+        .method = .GET,
+        .path = "/missing",
+        .query_string = "",
+        .body = "",
+        .cookies_raw = "",
+        .params = &.{},
+        .allocator = std.testing.allocator,
+    });
+
+    try std.testing.expect(resp.status == .not_found);
+    try std.testing.expect(resp.content_type == .html);
+    try std.testing.expect(std.mem.indexOf(u8, resp.body, "This route doesn't exist yet.") != null);
+}


### PR DESCRIPTION
## Summary
- fix `mer init` scaffold breakages so fresh apps build again
- add stronger scaffold-focused tests and starter smoke coverage
- vendor local `tools/codegen.zig` in new apps to reduce coupling to merjs internals
- add a release installer script and document the binary install path

## Verification
- `zig build test`
- `zig build cli && mer init rel && cd rel && zig build codegen && zig build test`
- `mer init /absolute/path/... && zig build codegen`
- `MER_INSTALL_DIR=... MER_INSTALL_VERSION=v0.2.2 sh scripts/install-mer.sh && mer --version`

Closes #67