### PR TITLE
feat: show compile errors in browser during mer dev

### DIFF
--- a/cli.zig
+++ b/cli.zig
@@ -315,30 +315,66 @@ fn cmdInit(alloc: std.mem.Allocator, name: []const u8) !void {
 
 // ── dev ─────────────────────────────────────────────────────────────────────
 
-fn cmdDev(alloc: std.mem.Allocator, extra_args: []const []const u8) !void {
-    std.fs.cwd().access("build.zig", .{}) catch {
-        print("mer: no build.zig found — are you in a merjs project?\n", .{});
-        std.process.exit(1);
-    };
+const DEV_ERROR_PATH = ".mer/dev-error.txt";
 
-    print("mer: running codegen...\n", .{});
-    {
-        const result = try std.process.Child.run(.{
-            .allocator = alloc,
-            .argv = &.{ "zig", "build", "codegen" },
-        });
-        defer alloc.free(result.stdout);
-        defer alloc.free(result.stderr);
-        const exited = result.term == .Exited;
-        if (!exited or result.term.Exited != 0) {
-            print("mer: codegen failed:\n{s}", .{result.stderr});
-            std.process.exit(1);
+fn writeDevErrorState(msg: []const u8) !void {
+    std.fs.cwd().makePath(".mer") catch {};
+    const file = try std.fs.cwd().createFile(DEV_ERROR_PATH, .{});
+    defer file.close();
+    try file.writeAll(msg);
+}
+
+fn clearDevErrorState() void {
+    std.fs.cwd().deleteFile(DEV_ERROR_PATH) catch {};
+}
+
+fn runBuildCommand(alloc: std.mem.Allocator, argv: []const []const u8) !std.process.Child.RunResult {
+    return std.process.Child.run(.{
+        .allocator = alloc,
+        .argv = argv,
+    });
+}
+
+fn scanWatchDir(alloc: std.mem.Allocator, mtimes: *std.StringHashMap(i128), dir_name: []const u8) bool {
+    var changed = false;
+    var dir = std.fs.cwd().openDir(dir_name, .{ .iterate = true }) catch return false;
+    defer dir.close();
+
+    var walker = dir.walk(alloc) catch return false;
+    defer walker.deinit();
+
+    while (walker.next() catch null) |entry| {
+        if (entry.kind != .file) continue;
+        const stat = dir.statFile(entry.path) catch continue;
+        const full = std.fmt.allocPrint(alloc, "{s}/{s}", .{ dir_name, entry.path }) catch continue;
+        defer alloc.free(full);
+
+        if (mtimes.get(full)) |prev| {
+            if (prev != stat.mtime) {
+                const key = alloc.dupe(u8, full) catch continue;
+                _ = mtimes.remove(full);
+                mtimes.put(key, stat.mtime) catch {};
+                changed = true;
+            }
+        } else {
+            const key = alloc.dupe(u8, full) catch continue;
+            mtimes.put(key, stat.mtime) catch {};
         }
     }
+    return changed;
+}
 
-    print("mer: starting dev server...\n", .{});
+fn pollDevChanges(alloc: std.mem.Allocator, mtimes: *std.StringHashMap(i128)) bool {
+    var changed = false;
+    for ([_][]const u8{ "app", "api", "src" }) |dir_name| {
+        if (scanWatchDir(alloc, mtimes, dir_name)) changed = true;
+    }
+    return changed;
+}
+
+fn startDevServer(alloc: std.mem.Allocator, extra_args: []const []const u8) !std.process.Child {
     var argv: std.ArrayList([]const u8) = .{};
-    defer argv.deinit(alloc);
+    errdefer argv.deinit(alloc);
     try argv.appendSlice(alloc, &.{ "zig", "build", "serve" });
     if (extra_args.len > 0) {
         try argv.append(alloc, "--");
@@ -349,7 +385,75 @@ fn cmdDev(alloc: std.mem.Allocator, extra_args: []const []const u8) !void {
     child.stdout_behavior = .Inherit;
     child.stderr_behavior = .Inherit;
     try child.spawn();
-    _ = try child.wait();
+    return child;
+}
+
+fn cmdDev(alloc: std.mem.Allocator, extra_args: []const []const u8) !void {
+    std.fs.cwd().access("build.zig", .{}) catch {
+        print("mer: no build.zig found — are you in a merjs project?\n", .{});
+        std.process.exit(1);
+    };
+
+    clearDevErrorState();
+    print("mer: running codegen...\n", .{});
+    {
+        const result = try runBuildCommand(alloc, &.{ "zig", "build", "codegen" });
+        defer alloc.free(result.stdout);
+        defer alloc.free(result.stderr);
+        const exited = result.term == .Exited;
+        if (!exited or result.term.Exited != 0) {
+            print("mer: codegen failed:\n{s}", .{result.stderr});
+            std.process.exit(1);
+        }
+    }
+
+    print("mer: starting dev server...\n", .{});
+    var child = try startDevServer(alloc, extra_args);
+    defer {
+        _ = child.kill() catch {};
+    }
+
+    var mtimes = std.StringHashMap(i128).init(alloc);
+    defer {
+        var it = mtimes.iterator();
+        while (it.next()) |entry| alloc.free(entry.key_ptr.*);
+        mtimes.deinit();
+    }
+    _ = pollDevChanges(alloc, &mtimes);
+
+    while (true) {
+        std.Thread.sleep(300 * std.time.ns_per_ms);
+        if (!pollDevChanges(alloc, &mtimes)) continue;
+
+        print("mer: rebuilding...\n", .{});
+        {
+            const result = try runBuildCommand(alloc, &.{ "zig", "build", "codegen" });
+            defer alloc.free(result.stdout);
+            defer alloc.free(result.stderr);
+            const exited = result.term == .Exited;
+            if (!exited or result.term.Exited != 0) {
+                try writeDevErrorState(result.stderr);
+                print("mer: codegen failed:\n{s}", .{result.stderr});
+                continue;
+            }
+        }
+
+        {
+            const result = try runBuildCommand(alloc, &.{ "zig", "build" });
+            defer alloc.free(result.stdout);
+            defer alloc.free(result.stderr);
+            const exited = result.term == .Exited;
+            if (!exited or result.term.Exited != 0) {
+                try writeDevErrorState(result.stderr);
+                print("mer: build failed:\n{s}", .{result.stderr});
+                continue;
+            }
+        }
+
+        clearDevErrorState();
+        _ = child.kill() catch {};
+        child = try startDevServer(alloc, extra_args);
+    }
 }
 
 // ── build ───────────────────────────────────────────────────────────────────

--- a/examples/site/app/counter.zig
+++ b/examples/site/app/counter.zig
@@ -44,6 +44,7 @@ fn page() h.Node {
             h.button(.{ .id = "btn-inc", .class = "btn btn-inc", .type = "button" }, "+"),
         }),
         h.span(.{ .class = "badge" }, "wasm32-freestanding"),
+        h.div(.{ .id = "runtime-status", .class = "runtime-status runtime-status--loading", .role = "status", .aria_live = "polite" }, "Checking WASM runtime..."),
         h.div(.{ .class = "config-note" }, .{
             h.raw("Bounds enforced at <strong>comptime</strong> via "),
             h.code(.{}, "counter_config.zig"),
@@ -61,12 +62,18 @@ fn comptimeIntStr(comptime val: i32) []const u8 {
 const counter_js =
     \\(async function(){
     \\  const display = document.getElementById('count-value');
+    \\  const status = document.getElementById('runtime-status');
 ++ std.fmt.comptimePrint(
     \\  const MIN={d}, MAX={d}, STEP={d}, INIT={d};
 , .{ cfg.min, cfg.max, cfg.step, cfg.initial }) ++
     \\  let count = INIT;
     \\  function clamp(v){ return Math.max(MIN, Math.min(MAX, v)); }
     \\  function sync(){ display.textContent = count; }
+    \\  function setStatus(kind, text, detail){
+    \\    status.className = 'runtime-status runtime-status--' + kind;
+    \\    status.textContent = text;
+    \\    if (detail) status.title = detail;
+    \\  }
     \\  try {
     \\    const {instance} = await WebAssembly.instantiateStreaming(fetch('/counter.wasm'),{});
     \\    const w = instance.exports;
@@ -74,10 +81,15 @@ const counter_js =
     \\    document.getElementById('btn-dec').onclick = ()=>{ w.decrement(); display.textContent = w.get_count(); };
     \\    document.getElementById('btn-reset').onclick = ()=>{ w.reset(); display.textContent = w.get_count(); };
     \\    display.textContent = w.get_count();
+    \\    setStatus('wasm', 'Running on Zig WASM', '');
     \\  } catch(e) {
     \\    document.getElementById('btn-inc').onclick = ()=>{ count = clamp(count + STEP); sync(); };
     \\    document.getElementById('btn-dec').onclick = ()=>{ count = clamp(count - STEP); sync(); };
     \\    document.getElementById('btn-reset').onclick = ()=>{ count = INIT; sync(); };
+    \\    sync();
+    \\    console.warn('counter.wasm failed, falling back to JS', e);
+    \\    const detail = e && e.message ? e.message : String(e);
+    \\    setStatus('fallback', 'JS fallback active: WASM failed to load', detail);
     \\  }
     \\})();
 ;
@@ -132,6 +144,18 @@ const page_css =
     \\  font-size:11px; color:var(--muted); background:var(--bg2);
     \\  border:1px solid var(--border); border-radius:100px;
     \\  padding:4px 12px; letter-spacing:0.04em;
+    \\}
+    \\.runtime-status {
+    \\  font-size:12px; border-radius:999px; padding:6px 12px;
+    \\  border:1px solid var(--border); background:var(--bg2);
+    \\  color:var(--muted);
+    \\}
+    \\.runtime-status--loading { color:var(--muted); }
+    \\.runtime-status--wasm {
+    \\  color:#0f766e; border-color:#99f6e4; background:#ecfdf5;
+    \\}
+    \\.runtime-status--fallback {
+    \\  color:#9a3412; border-color:#fdba74; background:#fff7ed;
     \\}
     \\.config-note {
     \\  font-size:12px; color:var(--muted); max-width:360px; line-height:1.6;

--- a/src/dev.zig
+++ b/src/dev.zig
@@ -13,8 +13,42 @@ pub const RouteDebugInfo = struct {
 pub const hot_reload_script =
     \\<script>
     \\(function(){
+    \\  const overlayId = '__mer-dev-overlay';
+    \\  function ensureOverlay(){
+    \\    let el = document.getElementById(overlayId);
+    \\    if (el) return el;
+    \\    el = document.createElement('div');
+    \\    el.id = overlayId;
+    \\    el.style.cssText = 'position:fixed;inset:0;z-index:99999;background:rgba(10,10,20,.94);color:#f5f7ff;padding:32px;font:14px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;overflow:auto;display:none';
+    \\    el.innerHTML = '<div style="max-width:960px;margin:0 auto"><div style="font-size:12px;letter-spacing:.08em;color:#ff8a8a;margin-bottom:12px">MERJS COMPILE ERROR</div><pre id="__mer-dev-overlay-pre" style="white-space:pre-wrap;word-break:break-word;background:#151827;border:1px solid #2f3448;border-radius:12px;padding:20px"></pre><div style="margin-top:12px;color:#9aa3b2">Fix the error and save to retry.</div></div>';
+    \\    document.body.appendChild(el);
+    \\    return el;
+    \\  }
+    \\  function hideOverlay(){
+    \\    const el = document.getElementById(overlayId);
+    \\    if (el) el.style.display = 'none';
+    \\  }
+    \\  function showOverlay(text){
+    \\    const el = ensureOverlay();
+    \\    const pre = document.getElementById('__mer-dev-overlay-pre');
+    \\    pre.textContent = text;
+    \\    el.style.display = 'block';
+    \\  }
     \\  const es = new EventSource('/_mer/events');
-    \\  es.onmessage = () => location.reload();
+    \\  es.onmessage = async () => {
+    \\    try {
+    \\      const res = await fetch('/_mer/dev-error?ts=' + Date.now(), { cache: 'no-store' });
+    \\      const text = await res.text();
+    \\      if (text && text.trim().length > 0) {
+    \\        showOverlay(text);
+    \\        return;
+    \\      }
+    \\      hideOverlay();
+    \\      location.reload();
+    \\    } catch (_) {
+    \\      location.reload();
+    \\    }
+    \\  };
     \\})();
     \\</script>
     \\</body>
@@ -86,6 +120,16 @@ pub fn sendErrorOverlay(std_req: *std.http.Server.Request, target: []const u8, e
         \\</div></body></html>
     );
     try bw.end();
+}
+
+pub fn serveDevError(alloc: std.mem.Allocator) !res_mod.Response {
+    const file = std.fs.cwd().openFile(".mer/dev-error.txt", .{ .mode = .read_only }) catch |err| switch (err) {
+        error.FileNotFound => return res_mod.Response.init(.ok, .text, ""),
+        else => return err,
+    };
+    defer file.close();
+    const body = try file.readToEndAlloc(alloc, 64 * 1024);
+    return res_mod.Response.init(.ok, .text, body);
 }
 
 /// Build a response for the /_mer/debug endpoint.

--- a/src/server.zig
+++ b/src/server.zig
@@ -225,6 +225,12 @@ fn serveRequest(
         return;
     }
 
+    if (dev and std.mem.eql(u8, path, "/_mer/dev-error")) {
+        const response = try dev_mod.serveDevError(alloc);
+        try sendResponse(std_req, response);
+        return;
+    }
+
     // Kuri browser automation proxy (debug mode).
     if (dev and std.mem.startsWith(u8, path, "/_mer/kuri")) {
         if (kuri) |k| {


### PR DESCRIPTION
## Summary
- make `mer dev` supervise rebuilds instead of only spawning the server once
- persist latest compiler stderr to a dev-only state file on build failures
- add `/_mer/dev-error` and teach the hot-reload client to render a browser overlay when compile errors exist

## Verification
- `zig build cli`
- `zig build test`

Closes #44