### PR TITLE
fix: pass process environ to Io backend, fixing AppDataDirUnavailable on Linux

### DIFF
--- a/cli.zig
+++ b/cli.zig
@@ -53,7 +53,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     const alloc = gpa.allocator();
 
     // Initialize std.Io runtime (Auto-selects Evented on Linux, Threaded elsewhere)
-    try runtime.init(alloc);
+    try runtime.init(alloc, init.environ);
     defer runtime.deinit();
 
     var arena_state: std.heap.ArenaAllocator = .init(std.heap.page_allocator);

--- a/examples/ui-showcase/src/main.zig
+++ b/examples/ui-showcase/src/main.zig
@@ -16,7 +16,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     const alloc = gpa.allocator();
 
     // Initialize std.Io runtime (Auto-selects Evented on Linux, Threaded elsewhere)
-    try runtime.init(alloc);
+    try runtime.init(alloc, init.environ);
     defer runtime.deinit();
 
     var arena_state: std.heap.ArenaAllocator = .init(std.heap.page_allocator);

--- a/src/main.zig
+++ b/src/main.zig
@@ -16,7 +16,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     const alloc = gpa.allocator();
 
     // Initialize std.Io runtime (Auto-selects Evented on Linux, Threaded elsewhere)
-    try runtime.init(alloc);
+    try runtime.init(alloc, init.environ);
     defer runtime.deinit();
 
     // 0.16: args come through init parameter.

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -21,15 +21,15 @@ const use_evented = blk: {
 // Evented storage only exists when supported
 var evented: if (use_evented) std.Io.Evented else void = undefined;
 
-pub fn init(gpa: std.mem.Allocator) !void {
+pub fn init(gpa: std.mem.Allocator, environ: std.process.Environ) !void {
     if (use_evented) {
         // Linux: Use Evented (io_uring)
         evented = undefined;
-        try std.Io.Evented.init(&evented, gpa, .{});
+        try std.Io.Evented.init(&evented, gpa, .{ .environ = environ });
         io = evented.io();
     } else {
         // macOS/Other: Use Threaded (Evented has bugs or isn't available)
-        threaded = std.Io.Threaded.init(gpa, .{});
+        threaded = std.Io.Threaded.init(gpa, .{ .environ = environ });
         io = threaded.io();
     }
 }

--- a/src/runtime_threaded.zig
+++ b/src/runtime_threaded.zig
@@ -6,13 +6,13 @@ const std = @import("std");
 /// This lets us flip between Threaded (today) and Evented (tomorrow for io_uring)
 /// without touching call sites.
 ///
-/// Initialize once in main(): runtime.init(gpa);
+/// Initialize once in main(): runtime.init(gpa, init.environ);
 /// Clean up on exit: defer runtime.deinit();
 pub var threaded: std.Io.Threaded = undefined;
 pub var io: std.Io = undefined;
 
-pub fn init(gpa: std.mem.Allocator) void {
-    threaded = std.Io.Threaded.init(gpa, .{});
+pub fn init(gpa: std.mem.Allocator, environ: std.process.Environ) void {
+    threaded = std.Io.Threaded.init(gpa, .{ .environ = environ });
     io = threaded.io();
 }
 

--- a/tools/codegen.zig
+++ b/tools/codegen.zig
@@ -10,7 +10,7 @@ pub fn main() !void {
     const alloc = gpa.allocator();
 
     // Initialize std.Io runtime (Auto-selects Evented on Linux, Threaded elsewhere)
-    try runtime.init(alloc);
+    try runtime.init(alloc, .empty);
     defer runtime.deinit();
 
     // Each entry stores the full relative path from the project root.


### PR DESCRIPTION
## Problem

`mer dev`, `mer build`, and `mer update` fail on Linux with:

```
error: unable to resolve zig cache directory: AppDataDirUnavailable
```

## Root Cause

`runtime.init()` calls `std.Io.Threaded.init(gpa, .{})` without passing the process `environ`. The default `InitOptions.environ` is `.empty`, so child processes get zero environment variables. Zig needs `HOME` to resolve its cache directory.

## Fix

Accept `environ` as a parameter in `runtime.init()` and forward it to the Io backend. All callsites now pass `init.environ` from `Init.Minimal`.

### Files changed (6 files):
- `src/runtime.zig` and `src/runtime_threaded.zig` - accept environ param
- `cli.zig`, `src/main.zig`, `examples/ui-showcase/src/main.zig` - pass `init.environ`
- `tools/codegen.zig` - pass `.empty` (no child spawning needed)