### PR TITLE
feat(native): expose a minimal macOS WebView host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, "feature/**", "feat/**"]
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
 
 jobs:
   build:
@@ -30,3 +30,24 @@ jobs:
 
       # TODO: re-enable E2E tests once kuri is updated for Zig 0.16
       # For now, just verify the build succeeds.
+
+  native-macos:
+    runs-on: macos-latest
+    name: Build native macOS app
+
+    steps:
+      - name: Checkout merjs
+        uses: actions/checkout@v4
+
+      - name: Setup Zig 0.16.0
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - name: Build app bundle
+        run: zig build desktop -Doptimize=ReleaseSmall
+
+      - name: Verify app bundle
+        run: |
+          test -x zig-out/MerApp.app/Contents/MacOS/merapp
+          test -f zig-out/MerApp.app/Contents/Info.plist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI — merjs build & test
 
 on:
   push:
-    branches: [main, "feature/**", "feat/**"]
+    branches: [main, "feature/**", "feat/**", "release/**"]
   pull_request:
     branches: [main, "release/**"]
 
@@ -44,10 +44,13 @@ jobs:
         with:
           version: 0.16.0
 
+      - name: Test framework
+        run: zig build test --summary all
+
       - name: Build app bundle
         run: zig build desktop -Doptimize=ReleaseSmall
 
       - name: Verify app bundle
         run: |
           test -x zig-out/MerApp.app/Contents/MacOS/merapp
-          test -f zig-out/MerApp.app/Contents/Info.plist
+          plutil -lint zig-out/MerApp.app/Contents/Info.plist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,26 @@ permissions:
   contents: write
 
 jobs:
+  native-macos:
+    runs-on: macos-latest
+    name: Verify native macOS app
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Zig 0.16.0
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - name: Build and verify app bundle
+        run: |
+          zig build desktop -Doptimize=ReleaseSmall
+          test -x zig-out/MerApp.app/Contents/MacOS/merapp
+          plutil -lint zig-out/MerApp.app/Contents/Info.plist
+
   build-and-release:
+    needs: native-macos
     runs-on: ubuntu-latest
     name: Build & publish release
 

--- a/build.zig
+++ b/build.zig
@@ -342,6 +342,7 @@ pub fn build(b: *std.Build) void {
         helpers.addDirModules(b, desktop_mod, mer_mod, "examples/site/api", "api", &.{});
         helpers.addRoutesModule(b, desktop_mod, mer_mod, "src/generated/routes.zig", "examples/site/app", "examples/site/api", site_extras);
         const desktop_exe = b.addExecutable(.{ .name = "merapp", .root_module = desktop_mod });
+        desktop_exe.step.dependOn(&run_codegen.step);
         desktop_mod.linkFramework("AppKit", .{});
         desktop_mod.linkFramework("WebKit", .{});
         desktop_mod.linkFramework("Foundation", .{});

--- a/build.zig
+++ b/build.zig
@@ -338,6 +338,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         });
         desktop_mod.addImport("mer", mer_mod);
+        desktop_mod.addImport("runtime", runtime_mod);
         helpers.addDirModules(b, desktop_mod, mer_mod, "examples/site/app", "app", site_extras);
         helpers.addDirModules(b, desktop_mod, mer_mod, "examples/site/api", "api", &.{});
         helpers.addRoutesModule(b, desktop_mod, mer_mod, "src/generated/routes.zig", "examples/site/app", "examples/site/api", site_extras);

--- a/examples/desktop/README.md
+++ b/examples/desktop/README.md
@@ -1,49 +1,54 @@
-# merjs Desktop (experimental)
+# merjs Desktop (macOS MVP)
 
-A native macOS app wrapper for merjs. Single Zig binary. Zero node_modules. No Electron.
+A native macOS host for merjs using the system `NSWindow` and `WKWebView`.
+It is a single Zig binary with no Node.js, Electron, or bundled browser.
 
 ```bash
 zig build desktop
 open zig-out/MerApp.app
 ```
 
-## What it does
+The build starts the example site on an ephemeral loopback port, waits for the
+server to bind, and opens `http://127.0.0.1:<port>/` in WKWebView. Closing the
+last window terminates the app.
 
-1. Spins up the merjs HTTP server on a random local port
-2. Opens a native `NSWindow` + `WKWebView` pointing at that port
-3. Packages as a proper `.app` bundle
+## Public host API
 
-## How it works
+Consumer entrypoints can present their own merjs server through `mer.native`:
 
-The ObjC bridge uses `extern fn` declarations for three runtime primitives (`objc_getClass`, `sel_registerName`, `objc_msgSend`) and typed function pointer casts for every method call. No `@cImport` of AppKit/WebKit headers — those contain Objective-C syntax that Zig's translate-c can't parse.
-
-See [`spike.zig`](spike.zig) for the full research notes and the interop pattern decision (issue #50).
-
-## Files
-
-| File | Purpose |
-|---|---|
-| `spike.zig` | #50 research spike — proves Zig→ObjC bridge pattern |
-| `main.zig` | Full app: server thread + NSApp run loop + WKWebView |
-
-## Status
-
-Experimental. The window opens and loads the merjs site from a local server. Known gaps:
-
-- No app icon
-- No `cmd+w` / `cmd+q` keyboard shortcuts wired to `[NSApp terminate:]`
-- No code signing (runs fine locally, not distributable via App Store)
-- Server shutdown on window close not yet wired
-
-## Build output
-
+```zig
+try mer.native.runLoopback(ready.port, .{
+    .title = "My App",
+    .width = 1200,
+    .height = 800,
+});
 ```
-zig-out/
-  bin/
-    merapp                    ← raw binary (also works standalone)
-  MerApp.app/
-    Contents/
-      MacOS/
-        merapp                ← same binary
-      Info.plist
-```
+
+`runLoopback` accepts only a nonzero loopback-server port. It constructs the
+URL internally, validates the title and dimensions, and returns after AppKit's
+event loop terminates. The app remains responsible for starting and stopping
+its server. A macOS executable using this API must link libc plus the AppKit,
+WebKit, and Foundation frameworks, as the repository's `desktop` target does.
+
+## Implementation
+
+The host calls three Objective-C runtime primitives and uses a typed
+`objc_msgSend` cast for each signature. It deliberately does not `@cImport`
+AppKit or WebKit headers because their Objective-C syntax is not accepted by
+Zig's C importer. See [`spike.zig`](spike.zig) for the original interop
+research.
+
+## Scope
+
+This MVP extracts the existing macOS window into a reusable framework API and
+keeps the working example build. It intentionally does **not** add:
+
+- a JavaScript-to-Zig bridge or native command permissions
+- a manifest or CLI scaffolding
+- code signing, notarization, or updates
+- Linux, Windows, or mobile hosts
+- generalized app-bundle metadata or resources
+
+The repository build still emits the example-specific `MerApp.app` bundle.
+Manifest-driven downstream packaging is a separate follow-up so this native
+runtime seam can be reviewed independently.

--- a/examples/desktop/README.md
+++ b/examples/desktop/README.md
@@ -8,9 +8,9 @@ zig build desktop
 open zig-out/MerApp.app
 ```
 
-The build starts the example site on an ephemeral loopback port, waits for the
-server to bind, and opens `http://127.0.0.1:<port>/` in WKWebView. Closing the
-last window terminates the app.
+When launched, the app starts the example site on an ephemeral loopback port,
+waits for the server to bind, and opens `http://127.0.0.1:<port>/` in WKWebView.
+Closing the last window terminates the app.
 
 ## Public host API
 
@@ -24,11 +24,12 @@ try mer.native.runLoopback(ready.port, .{
 });
 ```
 
-`runLoopback` accepts only a nonzero loopback-server port. It constructs the
-URL internally, validates the title and dimensions, and returns after AppKit's
-event loop terminates. The app remains responsible for starting and stopping
-its server. A macOS executable using this API must link libc plus the AppKit,
-WebKit, and Foundation frameworks, as the repository's `desktop` target does.
+`runLoopback` must be called from the process main thread and accepts only a
+nonzero loopback-server port. It constructs the URL internally, validates the
+title and dimensions, and returns after AppKit's event loop terminates. The app
+remains responsible for starting and stopping its server. A macOS executable
+using this API must link libc plus the AppKit, WebKit, and Foundation
+frameworks, as the repository's `desktop` target does.
 
 ## Implementation
 

--- a/examples/desktop/README.md
+++ b/examples/desktop/README.md
@@ -1,55 +1,53 @@
 # merjs Desktop (macOS MVP)
 
-A native macOS host for merjs using the system `NSWindow` and `WKWebView`.
-It is a single Zig binary with no Node.js, Electron, or bundled browser.
+A native macOS app wrapper for merjs. Single Zig binary. Zero node_modules. No Electron.
 
 ```bash
 zig build desktop
 open zig-out/MerApp.app
 ```
 
-When launched, the app starts the example site on an ephemeral loopback port,
-waits for the server to bind, and opens `http://127.0.0.1:<port>/` in WKWebView.
-Closing the last window terminates the app.
+## What it does
 
-## Public host API
+1. Spins up the merjs HTTP server on a random local port
+2. Opens a native `NSWindow` + `WKWebView` pointing at that port
+3. Packages as a proper `.app` bundle
 
-Consumer entrypoints can present their own merjs server through `mer.native`:
+## How it works
+
+The host calls the Objective-C runtime with typed function pointer casts for every method signature. No `@cImport` of AppKit/WebKit headers — those contain Objective-C syntax that Zig's translate-c can't parse.
+
+See [`spike.zig`](spike.zig) for the full research notes and the interop pattern decision (issue #50).
+
+## Public API
+
+Apps can present an existing loopback server from the process main thread:
 
 ```zig
 try mer.native.runLoopback(ready.port, .{
     .title = "My App",
-    .width = 1200,
-    .height = 800,
 });
 ```
 
-`runLoopback` must be called from the process main thread and accepts only a
-nonzero loopback-server port. It constructs the URL internally, validates the
-title and dimensions, and returns after AppKit's event loop terminates. The app
-remains responsible for starting and stopping its server. A macOS executable
-using this API must link libc plus the AppKit, WebKit, and Foundation
-frameworks, as the repository's `desktop` target does.
+The app owns server startup and shutdown. Its macOS target must link libc plus AppKit, WebKit, and Foundation, as this repository's `desktop` target does.
 
-## Implementation
+## Status
 
-The host calls three Objective-C runtime primitives and uses a typed
-`objc_msgSend` cast for each signature. It deliberately does not `@cImport`
-AppKit or WebKit headers because their Objective-C syntax is not accepted by
-Zig's C importer. See [`spike.zig`](spike.zig) for the original interop
-research.
+MVP. The window opens and loads the merjs site from a local server. Known gaps:
 
-## Scope
+- No app icon
+- No code signing (runs fine locally, not distributable via App Store)
+- No manifest, JS-to-Zig command bridge, updater, or cross-platform host
 
-This MVP extracts the existing macOS window into a reusable framework API and
-keeps the working example build. It intentionally does **not** add:
+## Build output
 
-- a JavaScript-to-Zig bridge or native command permissions
-- a manifest or CLI scaffolding
-- code signing, notarization, or updates
-- Linux, Windows, or mobile hosts
-- generalized app-bundle metadata or resources
-
-The repository build still emits the example-specific `MerApp.app` bundle.
-Manifest-driven downstream packaging is a separate follow-up so this native
-runtime seam can be reviewed independently.
+```
+zig-out/
+  bin/
+    merapp                    ← raw binary (also works standalone)
+  MerApp.app/
+    Contents/
+      MacOS/
+        merapp                ← same binary
+      Info.plist
+```

--- a/examples/desktop/main.zig
+++ b/examples/desktop/main.zig
@@ -4,6 +4,7 @@
 /// background thread for the lifetime of the desktop process.
 const std = @import("std");
 const mer = @import("mer");
+const runtime = @import("runtime");
 
 const ServerCtx = struct {
     ready: mer.ServerReady = .{},
@@ -28,6 +29,7 @@ fn runServer(ctx: *ServerCtx) void {
 pub fn main() !void {
     var gpa: std.heap.DebugAllocator(.{}) = .init;
     const allocator = gpa.allocator();
+    try runtime.init(allocator);
 
     const ctx = try allocator.create(ServerCtx);
     ctx.* = .{ .allocator = allocator };

--- a/examples/desktop/main.zig
+++ b/examples/desktop/main.zig
@@ -1,82 +1,10 @@
-/// merjs Desktop — native macOS app wrapper
+/// merjs Desktop — native macOS app wrapper.
 ///
-/// Architecture (#53):
-///   main thread  →  NSApp.run() (AppKit requires main thread)
-///   bg thread    →  merjs HTTP server on port 0 (OS assigns free port)
-///   sync         →  std.Thread.ResetEvent (server signals ready → main loads URL)
+/// AppKit owns the main thread. The merjs loopback server runs on a detached
+/// background thread for the lifetime of the desktop process.
 const std = @import("std");
 const mer = @import("mer");
-// ObjC runtime — no @cImport needed (proven in spike #50)
-extern fn objc_getClass(name: [*:0]const u8) ?*anyopaque;
-extern fn sel_registerName(name: [*:0]const u8) ?*anyopaque;
-extern fn objc_msgSend() void;
 
-// Types
-const Id = ?*anyopaque;
-const Sel = ?*anyopaque;
-const CGFloat = f64;
-const CGPoint = extern struct { x: CGFloat, y: CGFloat };
-const CGSize = extern struct { width: CGFloat, height: CGFloat };
-const CGRect = extern struct { origin: CGPoint, size: CGSize };
-const NSUInteger = c_ulong;
-const NSInteger = c_long;
-const BOOL = i8;
-
-// AppKit constants
-const NSWindowStyleMaskTitled: NSUInteger = 1;
-const NSWindowStyleMaskClosable: NSUInteger = 2;
-const NSWindowStyleMaskMiniaturizable: NSUInteger = 4;
-const NSWindowStyleMaskResizable: NSUInteger = 8;
-const NSBackingStoreBuffered: NSUInteger = 2;
-const NSApplicationActivationPolicyRegular: NSInteger = 0;
-const YES: BOOL = 1;
-const NO: BOOL = 0;
-
-fn cls(name: [*:0]const u8) Id {
-    return objc_getClass(name);
-}
-fn sel(name: [*:0]const u8) Sel {
-    return sel_registerName(name);
-}
-
-fn send(recv: Id, s: Sel) Id {
-    const F = *const fn (Id, Sel) callconv(.c) Id;
-    return @as(F, @ptrCast(&objc_msgSend))(recv, s);
-}
-fn sendv(recv: Id, s: Sel) void {
-    const F = *const fn (Id, Sel) callconv(.c) void;
-    @as(F, @ptrCast(&objc_msgSend))(recv, s);
-}
-fn send1(recv: Id, s: Sel, a: Id) Id {
-    const F = *const fn (Id, Sel, Id) callconv(.c) Id;
-    return @as(F, @ptrCast(&objc_msgSend))(recv, s, a);
-}
-fn send1v(recv: Id, s: Sel, a: Id) void {
-    const F = *const fn (Id, Sel, Id) callconv(.c) void;
-    @as(F, @ptrCast(&objc_msgSend))(recv, s, a);
-}
-fn sendStr(recv: Id, s: Sel, str: [*:0]const u8) Id {
-    const F = *const fn (Id, Sel, [*:0]const u8) callconv(.c) Id;
-    return @as(F, @ptrCast(&objc_msgSend))(recv, s, str);
-}
-fn sendIntv(recv: Id, s: Sel, a: NSInteger) void {
-    const F = *const fn (Id, Sel, NSInteger) callconv(.c) void;
-    @as(F, @ptrCast(&objc_msgSend))(recv, s, a);
-}
-fn sendBoolv(recv: Id, s: Sel, a: BOOL) void {
-    const F = *const fn (Id, Sel, BOOL) callconv(.c) void;
-    @as(F, @ptrCast(&objc_msgSend))(recv, s, a);
-}
-fn sendWindowInit(recv: Id, s: Sel, rect: CGRect, style: NSUInteger, backing: NSUInteger, defer_: BOOL) Id {
-    const F = *const fn (Id, Sel, CGRect, NSUInteger, NSUInteger, BOOL) callconv(.c) Id;
-    return @as(F, @ptrCast(&objc_msgSend))(recv, s, rect, style, backing, defer_);
-}
-fn sendWebViewInit(recv: Id, s: Sel, frame: CGRect, config: Id) Id {
-    const F = *const fn (Id, Sel, CGRect, Id) callconv(.c) Id;
-    return @as(F, @ptrCast(&objc_msgSend))(recv, s, frame, config);
-}
-
-// Server thread context
 const ServerCtx = struct {
     ready: mer.ServerReady = .{},
     allocator: std.mem.Allocator,
@@ -85,83 +13,38 @@ const ServerCtx = struct {
 fn runServer(ctx: *ServerCtx) void {
     var router = mer.Router.fromGenerated(ctx.allocator, @import("routes"));
     defer router.deinit();
-    var srv = mer.Server.init(ctx.allocator, .{
+    var server = mer.Server.init(ctx.allocator, .{
         .host = "127.0.0.1",
-        .port = 0, // OS assigns a free port
+        .port = 0,
         .dev = false,
         .ready = &ctx.ready,
     }, &router, null);
-    srv.listen() catch |err| {
+    server.listen() catch |err| {
         std.log.err("server listen failed: {}", .{err});
-        ctx.ready.event.set(); // unblock main thread even on failure
+        ctx.ready.set();
     };
 }
 
 pub fn main() !void {
     var gpa: std.heap.DebugAllocator(.{}) = .init;
-    defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    // Allocate server context on heap so the thread can outlive this stack frame
     const ctx = try allocator.create(ServerCtx);
     ctx.* = .{ .allocator = allocator };
+    const server_thread = try std.Thread.spawn(.{}, runServer, .{ctx});
+    server_thread.detach();
 
-    // Spawn HTTP server on background thread (#53)
-    const thread = try std.Thread.spawn(.{}, runServer, .{ctx});
-    thread.detach();
+    ctx.ready.wait();
+    if (ctx.ready.port == 0) return error.ServerFailed;
+    std.log.info("merjs server ready on port {d}", .{ctx.ready.port});
 
-    // Block until server is bound and ready (#51)
-    ctx.ready.event.wait();
-    const port = ctx.ready.port;
-    if (port == 0) return error.ServerFailed;
-    std.log.info("merjs server ready on port {d}", .{port});
+    try mer.native.runLoopback(ctx.ready.port, .{
+        .title = "merjs",
+        .width = 1024,
+        .height = 720,
+    });
 
-    // Build the URL string
-    var url_buf: [64]u8 = undefined;
-    const url_str = try std.fmt.bufPrintZ(&url_buf, "http://127.0.0.1:{d}/", .{port});
-
-    // ── AppKit setup (must run on main thread) (#52) ──────────────────────
-    const app = send(cls("NSApplication"), sel("sharedApplication"));
-    sendIntv(app, sel("setActivationPolicy:"), NSApplicationActivationPolicyRegular);
-
-    const frame = CGRect{
-        .origin = .{ .x = 0, .y = 0 },
-        .size = .{ .width = 1280, .height = 820 },
-    };
-    const style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
-        NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
-    const window = sendWindowInit(
-        send(cls("NSWindow"), sel("alloc")),
-        sel("initWithContentRect:styleMask:backing:defer:"),
-        frame,
-        style,
-        NSBackingStoreBuffered,
-        NO,
-    );
-    const title = sendStr(cls("NSString"), sel("stringWithUTF8String:"), "merjs");
-    send1v(window, sel("setTitle:"), title);
-
-    // WKWebView
-    const wkconfig = send(
-        send(cls("WKWebViewConfiguration"), sel("alloc")),
-        sel("init"),
-    );
-    const webview = sendWebViewInit(
-        send(cls("WKWebView"), sel("alloc")),
-        sel("initWithFrame:configuration:"),
-        frame,
-        wkconfig,
-    );
-    send1v(window, sel("setContentView:"), webview);
-
-    // Load the merjs server URL
-    const ns_url_str = sendStr(cls("NSString"), sel("stringWithUTF8String:"), url_str.ptr);
-    const url = send1(cls("NSURL"), sel("URLWithString:"), ns_url_str);
-    const request = send1(cls("NSURLRequest"), sel("requestWithURL:"), url);
-    _ = send1(webview, sel("loadRequest:"), request);
-
-    // Show window and run event loop
-    send1v(window, sel("makeKeyAndOrderFront:"), null);
-    sendBoolv(app, sel("activateIgnoringOtherApps:"), YES);
-    sendv(app, sel("run")); // blocks until window is closed
+    // Server.listen currently has process-lifetime semantics. Exit without
+    // unwinding allocator state still owned by its detached thread.
+    std.process.exit(0);
 }

--- a/src/mer.zig
+++ b/src/mer.zig
@@ -203,4 +203,5 @@ pub const Server = @import("server.zig").Server;
 pub const Config = @import("server.zig").Config;
 pub const ServerReady = @import("server.zig").ServerReady;
 pub const Watcher = @import("watcher.zig").Watcher;
+pub const native = @import("native.zig");
 pub const runPrerender = @import("prerender.zig").run;

--- a/src/native.zig
+++ b/src/native.zig
@@ -1,0 +1,51 @@
+//! Minimal native desktop primitives.
+//!
+//! The first supported host is macOS. It presents a merjs loopback server in
+//! the system WKWebView; server startup and shutdown remain owned by the app.
+
+const builtin = @import("builtin");
+const std = @import("std");
+
+pub const WindowConfig = struct {
+    title: []const u8 = "merjs",
+    width: u32 = 1024,
+    height: u32 = 720,
+};
+
+pub const Error = error{
+    UnsupportedPlatform,
+    InvalidPort,
+    InvalidTitle,
+    InvalidWindowSize,
+    NativeRuntimeUnavailable,
+};
+
+fn validate(port: u16, config: WindowConfig) Error!void {
+    if (port == 0) return error.InvalidPort;
+    if (config.title.len == 0 or config.title.len > 255 or
+        std.mem.indexOfScalar(u8, config.title, 0) != null)
+    {
+        return error.InvalidTitle;
+    }
+    if (config.width < 320 or config.width > 8192 or
+        config.height < 240 or config.height > 8192)
+    {
+        return error.InvalidWindowSize;
+    }
+}
+
+/// Run the platform event loop and show a native window for a loopback server.
+/// Returns after the user terminates the app or closes its last window.
+pub fn runLoopback(port: u16, config: WindowConfig) Error!void {
+    try validate(port, config);
+    if (comptime builtin.os.tag != .macos) return error.UnsupportedPlatform;
+    return @import("native/macos.zig").run(port, config);
+}
+
+test "native window configuration rejects unsafe values" {
+    try std.testing.expectError(error.InvalidPort, validate(0, .{}));
+    try std.testing.expectError(error.InvalidTitle, validate(3000, .{ .title = "" }));
+    try std.testing.expectError(error.InvalidTitle, validate(3000, .{ .title = "bad\x00title" }));
+    try std.testing.expectError(error.InvalidWindowSize, validate(3000, .{ .width = 100 }));
+    try validate(3000, .{});
+}

--- a/src/native.zig
+++ b/src/native.zig
@@ -17,13 +17,15 @@ pub const Error = error{
     InvalidPort,
     InvalidTitle,
     InvalidWindowSize,
+    WrongThread,
     NativeRuntimeUnavailable,
 };
 
 fn validate(port: u16, config: WindowConfig) Error!void {
     if (port == 0) return error.InvalidPort;
     if (config.title.len == 0 or config.title.len > 255 or
-        std.mem.indexOfScalar(u8, config.title, 0) != null)
+        std.mem.indexOfScalar(u8, config.title, 0) != null or
+        !std.unicode.utf8ValidateSlice(config.title))
     {
         return error.InvalidTitle;
     }
@@ -35,7 +37,8 @@ fn validate(port: u16, config: WindowConfig) Error!void {
 }
 
 /// Run the platform event loop and show a native window for a loopback server.
-/// Returns after the user terminates the app or closes its last window.
+/// Must be called from the process main thread. Returns after the user
+/// terminates the app or closes its last window.
 pub fn runLoopback(port: u16, config: WindowConfig) Error!void {
     try validate(port, config);
     if (comptime builtin.os.tag != .macos) return error.UnsupportedPlatform;
@@ -46,6 +49,7 @@ test "native window configuration rejects unsafe values" {
     try std.testing.expectError(error.InvalidPort, validate(0, .{}));
     try std.testing.expectError(error.InvalidTitle, validate(3000, .{ .title = "" }));
     try std.testing.expectError(error.InvalidTitle, validate(3000, .{ .title = "bad\x00title" }));
+    try std.testing.expectError(error.InvalidTitle, validate(3000, .{ .title = &.{0xff} }));
     try std.testing.expectError(error.InvalidWindowSize, validate(3000, .{ .width = 100 }));
     try validate(3000, .{});
 }

--- a/src/native/macos.zig
+++ b/src/native/macos.zig
@@ -18,6 +18,7 @@ extern fn objc_msgSend() void;
 extern fn objc_allocateClassPair(superclass: Id, name: [*:0]const u8, extra_bytes: usize) Id;
 extern fn class_addMethod(cls: Id, name: Sel, imp: *const anyopaque, types: [*:0]const u8) BOOL;
 extern fn objc_registerClassPair(cls: Id) void;
+extern fn objc_disposeClassPair(cls: Id) void;
 
 const NSWindowStyleMaskTitled: NSUInteger = 1;
 const NSWindowStyleMaskClosable: NSUInteger = 2;
@@ -58,9 +59,14 @@ fn sendOneVoid(recv: Id, selector: Sel, arg: Id) void {
     @as(F, @ptrCast(&objc_msgSend))(recv, selector, arg);
 }
 
-fn sendIntegerVoid(recv: Id, selector: Sel, value: NSInteger) void {
-    const F = *const fn (Id, Sel, NSInteger) callconv(.c) void;
-    @as(F, @ptrCast(&objc_msgSend))(recv, selector, value);
+fn sendOneBool(recv: Id, selector: Sel, arg: Id) BOOL {
+    const F = *const fn (Id, Sel, Id) callconv(.c) BOOL;
+    return @as(F, @ptrCast(&objc_msgSend))(recv, selector, arg);
+}
+
+fn sendIntegerBool(recv: Id, selector: Sel, value: NSInteger) BOOL {
+    const F = *const fn (Id, Sel, NSInteger) callconv(.c) BOOL;
+    return @as(F, @ptrCast(&objc_msgSend))(recv, selector, value);
 }
 
 fn sendBool(recv: Id, selector: Sel) BOOL {
@@ -90,23 +96,25 @@ fn initWebView(recv: Id, selector: Sel, frame: CGRect, config: Id) Id {
     return @as(F, @ptrCast(&objc_msgSend))(recv, selector, frame, config);
 }
 
-fn shouldTerminateAfterLastWindow(_: Id, _: Sel, _: Id) callconv(.c) BOOL {
-    return YES;
+fn stopAfterLastWindow(_: Id, _: Sel, app: Id) callconv(.c) BOOL {
+    sendOneVoid(app, sel("stop:"), null);
+    return NO;
 }
 
 fn createAppDelegate() Id {
-    const class = cls("MerNativeAppDelegate") orelse blk: {
+    const method = sel("applicationShouldTerminateAfterLastWindowClosed:");
+    const class_name = "MerjsNativeWindowLifecycleDelegate_v1";
+    const class = cls(class_name) orelse blk: {
         const superclass = cls("NSObject") orelse return null;
-        const new_class = objc_allocateClassPair(superclass, "MerNativeAppDelegate", 0) orelse return null;
-        if (class_addMethod(
-            new_class,
-            sel("applicationShouldTerminateAfterLastWindowClosed:"),
-            @ptrCast(&shouldTerminateAfterLastWindow),
-            "c@:@",
-        ) == NO) return null;
+        const new_class = objc_allocateClassPair(superclass, class_name, 0) orelse return null;
+        if (class_addMethod(new_class, method, @ptrCast(&stopAfterLastWindow), "c@:@") == NO) {
+            objc_disposeClassPair(new_class);
+            return null;
+        }
         objc_registerClassPair(new_class);
         break :blk new_class;
     };
+    if (sendOneBool(class, sel("instancesRespondToSelector:"), method) == NO) return null;
     return send(send(class, sel("alloc")), sel("init"));
 }
 
@@ -122,7 +130,8 @@ pub fn run(port: u16, config: anytype) error{ WrongThread, NativeRuntimeUnavaila
     const app_class = cls("NSApplication") orelse return error.NativeRuntimeUnavailable;
     const app = send(app_class, sel("sharedApplication")) orelse
         return error.NativeRuntimeUnavailable;
-    sendIntegerVoid(app, sel("setActivationPolicy:"), NSApplicationActivationPolicyRegular);
+    if (sendIntegerBool(app, sel("setActivationPolicy:"), NSApplicationActivationPolicyRegular) == NO)
+        return error.NativeRuntimeUnavailable;
 
     app_delegate = createAppDelegate() orelse return error.NativeRuntimeUnavailable;
     sendOneVoid(app, sel("setDelegate:"), app_delegate);

--- a/src/native/macos.zig
+++ b/src/native/macos.zig
@@ -63,6 +63,11 @@ fn sendIntegerVoid(recv: Id, selector: Sel, value: NSInteger) void {
     @as(F, @ptrCast(&objc_msgSend))(recv, selector, value);
 }
 
+fn sendBool(recv: Id, selector: Sel) BOOL {
+    const F = *const fn (Id, Sel) callconv(.c) BOOL;
+    return @as(F, @ptrCast(&objc_msgSend))(recv, selector);
+}
+
 fn sendBoolVoid(recv: Id, selector: Sel, value: BOOL) void {
     const F = *const fn (Id, Sel, BOOL) callconv(.c) void;
     @as(F, @ptrCast(&objc_msgSend))(recv, selector, value);
@@ -105,7 +110,10 @@ fn createAppDelegate() Id {
     return send(send(class, sel("alloc")), sel("init"));
 }
 
-pub fn run(port: u16, config: anytype) error{NativeRuntimeUnavailable}!void {
+pub fn run(port: u16, config: anytype) error{ WrongThread, NativeRuntimeUnavailable }!void {
+    const thread_class = cls("NSThread") orelse return error.NativeRuntimeUnavailable;
+    if (sendBool(thread_class, sel("isMainThread")) == NO) return error.WrongThread;
+
     const pool_class = cls("NSAutoreleasePool") orelse return error.NativeRuntimeUnavailable;
     const pool = send(send(pool_class, sel("alloc")), sel("init")) orelse
         return error.NativeRuntimeUnavailable;
@@ -118,6 +126,11 @@ pub fn run(port: u16, config: anytype) error{NativeRuntimeUnavailable}!void {
 
     app_delegate = createAppDelegate() orelse return error.NativeRuntimeUnavailable;
     sendOneVoid(app, sel("setDelegate:"), app_delegate);
+    defer {
+        sendOneVoid(app, sel("setDelegate:"), null);
+        sendVoid(app_delegate, sel("release"));
+        app_delegate = null;
+    }
 
     const frame = CGRect{
         .origin = .{ .x = 0, .y = 0 },
@@ -135,6 +148,8 @@ pub fn run(port: u16, config: anytype) error{NativeRuntimeUnavailable}!void {
         frame,
         style,
     ) orelse return error.NativeRuntimeUnavailable;
+    sendBoolVoid(window, sel("setReleasedWhenClosed:"), NO);
+    defer sendVoid(window, sel("release"));
 
     var title_buffer: [256]u8 = undefined;
     @memcpy(title_buffer[0..config.title.len], config.title);
@@ -149,12 +164,14 @@ pub fn run(port: u16, config: anytype) error{NativeRuntimeUnavailable}!void {
         return error.NativeRuntimeUnavailable;
     const webview_config = send(send(webview_config_class, sel("alloc")), sel("init")) orelse
         return error.NativeRuntimeUnavailable;
+    defer sendVoid(webview_config, sel("release"));
     const webview = initWebView(
         send(webview_class, sel("alloc")),
         sel("initWithFrame:configuration:"),
         frame,
         webview_config,
     ) orelse return error.NativeRuntimeUnavailable;
+    defer sendVoid(webview, sel("release"));
     sendOneVoid(window, sel("setContentView:"), webview);
 
     var url_buffer: [64]u8 = undefined;

--- a/src/native/macos.zig
+++ b/src/native/macos.zig
@@ -19,6 +19,8 @@ extern fn objc_allocateClassPair(superclass: Id, name: [*:0]const u8, extra_byte
 extern fn class_addMethod(cls: Id, name: Sel, imp: *const anyopaque, types: [*:0]const u8) BOOL;
 extern fn objc_registerClassPair(cls: Id) void;
 extern fn objc_disposeClassPair(cls: Id) void;
+extern fn class_getInstanceMethod(cls: Id, name: Sel) Id;
+extern fn method_getImplementation(method: Id) ?*const anyopaque;
 
 const NSWindowStyleMaskTitled: NSUInteger = 1;
 const NSWindowStyleMaskClosable: NSUInteger = 2;
@@ -57,11 +59,6 @@ fn sendOne(recv: Id, selector: Sel, arg: Id) Id {
 fn sendOneVoid(recv: Id, selector: Sel, arg: Id) void {
     const F = *const fn (Id, Sel, Id) callconv(.c) void;
     @as(F, @ptrCast(&objc_msgSend))(recv, selector, arg);
-}
-
-fn sendOneBool(recv: Id, selector: Sel, arg: Id) BOOL {
-    const F = *const fn (Id, Sel, Id) callconv(.c) BOOL;
-    return @as(F, @ptrCast(&objc_msgSend))(recv, selector, arg);
 }
 
 fn sendIntegerBool(recv: Id, selector: Sel, value: NSInteger) BOOL {
@@ -106,7 +103,8 @@ fn createAppDelegate() Id {
     const class_name = "MerjsNativeWindowLifecycleDelegate_v1";
     const class = cls(class_name) orelse blk: {
         const superclass = cls("NSObject") orelse return null;
-        const new_class = objc_allocateClassPair(superclass, class_name, 0) orelse return null;
+        const new_class = objc_allocateClassPair(superclass, class_name, 0) orelse
+            break :blk cls(class_name) orelse return null;
         if (class_addMethod(new_class, method, @ptrCast(&stopAfterLastWindow), "c@:@") == NO) {
             objc_disposeClassPair(new_class);
             return null;
@@ -114,7 +112,10 @@ fn createAppDelegate() Id {
         objc_registerClassPair(new_class);
         break :blk new_class;
     };
-    if (sendOneBool(class, sel("instancesRespondToSelector:"), method) == NO) return null;
+    const registered_method = class_getInstanceMethod(class, method) orelse return null;
+    const implementation = method_getImplementation(registered_method) orelse return null;
+    const expected: *const anyopaque = @ptrCast(&stopAfterLastWindow);
+    if (implementation != expected) return null;
     return send(send(class, sel("alloc")), sel("init"));
 }
 

--- a/src/native/macos.zig
+++ b/src/native/macos.zig
@@ -1,0 +1,176 @@
+//! macOS WKWebView host using the Objective-C runtime directly.
+//! AppKit headers are intentionally not translated: their Objective-C syntax
+//! is not accepted by Zig's C importer.
+
+const Id = ?*anyopaque;
+const Sel = ?*anyopaque;
+const BOOL = i8;
+const CGFloat = f64;
+const NSInteger = c_long;
+const NSUInteger = c_ulong;
+const CGPoint = extern struct { x: CGFloat, y: CGFloat };
+const CGSize = extern struct { width: CGFloat, height: CGFloat };
+const CGRect = extern struct { origin: CGPoint, size: CGSize };
+
+extern fn objc_getClass(name: [*:0]const u8) Id;
+extern fn sel_registerName(name: [*:0]const u8) Sel;
+extern fn objc_msgSend() void;
+extern fn objc_allocateClassPair(superclass: Id, name: [*:0]const u8, extra_bytes: usize) Id;
+extern fn class_addMethod(cls: Id, name: Sel, imp: *const anyopaque, types: [*:0]const u8) BOOL;
+extern fn objc_registerClassPair(cls: Id) void;
+
+const NSWindowStyleMaskTitled: NSUInteger = 1;
+const NSWindowStyleMaskClosable: NSUInteger = 2;
+const NSWindowStyleMaskMiniaturizable: NSUInteger = 4;
+const NSWindowStyleMaskResizable: NSUInteger = 8;
+const NSBackingStoreBuffered: NSUInteger = 2;
+const NSApplicationActivationPolicyRegular: NSInteger = 0;
+const YES: BOOL = 1;
+const NO: BOOL = 0;
+
+var app_delegate: Id = null;
+
+fn cls(name: [*:0]const u8) Id {
+    return objc_getClass(name);
+}
+
+fn sel(name: [*:0]const u8) Sel {
+    return sel_registerName(name);
+}
+
+fn send(recv: Id, selector: Sel) Id {
+    const F = *const fn (Id, Sel) callconv(.c) Id;
+    return @as(F, @ptrCast(&objc_msgSend))(recv, selector);
+}
+
+fn sendVoid(recv: Id, selector: Sel) void {
+    const F = *const fn (Id, Sel) callconv(.c) void;
+    @as(F, @ptrCast(&objc_msgSend))(recv, selector);
+}
+
+fn sendOne(recv: Id, selector: Sel, arg: Id) Id {
+    const F = *const fn (Id, Sel, Id) callconv(.c) Id;
+    return @as(F, @ptrCast(&objc_msgSend))(recv, selector, arg);
+}
+
+fn sendOneVoid(recv: Id, selector: Sel, arg: Id) void {
+    const F = *const fn (Id, Sel, Id) callconv(.c) void;
+    @as(F, @ptrCast(&objc_msgSend))(recv, selector, arg);
+}
+
+fn sendIntegerVoid(recv: Id, selector: Sel, value: NSInteger) void {
+    const F = *const fn (Id, Sel, NSInteger) callconv(.c) void;
+    @as(F, @ptrCast(&objc_msgSend))(recv, selector, value);
+}
+
+fn sendBoolVoid(recv: Id, selector: Sel, value: BOOL) void {
+    const F = *const fn (Id, Sel, BOOL) callconv(.c) void;
+    @as(F, @ptrCast(&objc_msgSend))(recv, selector, value);
+}
+
+fn initWindow(recv: Id, selector: Sel, frame: CGRect, style: NSUInteger) Id {
+    const F = *const fn (Id, Sel, CGRect, NSUInteger, NSUInteger, BOOL) callconv(.c) Id;
+    return @as(F, @ptrCast(&objc_msgSend))(
+        recv,
+        selector,
+        frame,
+        style,
+        NSBackingStoreBuffered,
+        NO,
+    );
+}
+
+fn initWebView(recv: Id, selector: Sel, frame: CGRect, config: Id) Id {
+    const F = *const fn (Id, Sel, CGRect, Id) callconv(.c) Id;
+    return @as(F, @ptrCast(&objc_msgSend))(recv, selector, frame, config);
+}
+
+fn shouldTerminateAfterLastWindow(_: Id, _: Sel, _: Id) callconv(.c) BOOL {
+    return YES;
+}
+
+fn createAppDelegate() Id {
+    const class = cls("MerNativeAppDelegate") orelse blk: {
+        const superclass = cls("NSObject") orelse return null;
+        const new_class = objc_allocateClassPair(superclass, "MerNativeAppDelegate", 0) orelse return null;
+        if (class_addMethod(
+            new_class,
+            sel("applicationShouldTerminateAfterLastWindowClosed:"),
+            @ptrCast(&shouldTerminateAfterLastWindow),
+            "c@:@",
+        ) == NO) return null;
+        objc_registerClassPair(new_class);
+        break :blk new_class;
+    };
+    return send(send(class, sel("alloc")), sel("init"));
+}
+
+pub fn run(port: u16, config: anytype) error{NativeRuntimeUnavailable}!void {
+    const pool_class = cls("NSAutoreleasePool") orelse return error.NativeRuntimeUnavailable;
+    const pool = send(send(pool_class, sel("alloc")), sel("init")) orelse
+        return error.NativeRuntimeUnavailable;
+    defer sendVoid(pool, sel("drain"));
+
+    const app_class = cls("NSApplication") orelse return error.NativeRuntimeUnavailable;
+    const app = send(app_class, sel("sharedApplication")) orelse
+        return error.NativeRuntimeUnavailable;
+    sendIntegerVoid(app, sel("setActivationPolicy:"), NSApplicationActivationPolicyRegular);
+
+    app_delegate = createAppDelegate() orelse return error.NativeRuntimeUnavailable;
+    sendOneVoid(app, sel("setDelegate:"), app_delegate);
+
+    const frame = CGRect{
+        .origin = .{ .x = 0, .y = 0 },
+        .size = .{
+            .width = @floatFromInt(config.width),
+            .height = @floatFromInt(config.height),
+        },
+    };
+    const style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
+        NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
+    const window_class = cls("NSWindow") orelse return error.NativeRuntimeUnavailable;
+    const window = initWindow(
+        send(window_class, sel("alloc")),
+        sel("initWithContentRect:styleMask:backing:defer:"),
+        frame,
+        style,
+    ) orelse return error.NativeRuntimeUnavailable;
+
+    var title_buffer: [256]u8 = undefined;
+    @memcpy(title_buffer[0..config.title.len], config.title);
+    title_buffer[config.title.len] = 0;
+    const string_class = cls("NSString") orelse return error.NativeRuntimeUnavailable;
+    const title = sendOne(string_class, sel("stringWithUTF8String:"), @ptrCast(&title_buffer)) orelse
+        return error.NativeRuntimeUnavailable;
+    sendOneVoid(window, sel("setTitle:"), title);
+
+    const webview_class = cls("WKWebView") orelse return error.NativeRuntimeUnavailable;
+    const webview_config_class = cls("WKWebViewConfiguration") orelse
+        return error.NativeRuntimeUnavailable;
+    const webview_config = send(send(webview_config_class, sel("alloc")), sel("init")) orelse
+        return error.NativeRuntimeUnavailable;
+    const webview = initWebView(
+        send(webview_class, sel("alloc")),
+        sel("initWithFrame:configuration:"),
+        frame,
+        webview_config,
+    ) orelse return error.NativeRuntimeUnavailable;
+    sendOneVoid(window, sel("setContentView:"), webview);
+
+    var url_buffer: [64]u8 = undefined;
+    const std = @import("std");
+    const url = std.fmt.bufPrintZ(&url_buffer, "http://127.0.0.1:{d}/", .{port}) catch
+        return error.NativeRuntimeUnavailable;
+    const url_class = cls("NSURL") orelse return error.NativeRuntimeUnavailable;
+    const ns_url = sendOne(url_class, sel("URLWithString:"), @ptrCast(url.ptr)) orelse
+        return error.NativeRuntimeUnavailable;
+    const request_class = cls("NSURLRequest") orelse return error.NativeRuntimeUnavailable;
+    const request = sendOne(request_class, sel("requestWithURL:"), ns_url) orelse
+        return error.NativeRuntimeUnavailable;
+    _ = sendOne(webview, sel("loadRequest:"), request);
+
+    sendVoid(window, sel("center"));
+    sendOneVoid(window, sel("makeKeyAndOrderFront:"), null);
+    sendBoolVoid(app, sel("activateIgnoringOtherApps:"), YES);
+    sendVoid(app, sel("run"));
+}

--- a/src/native/macos.zig
+++ b/src/native/macos.zig
@@ -178,8 +178,10 @@ pub fn run(port: u16, config: anytype) error{ WrongThread, NativeRuntimeUnavaila
     const std = @import("std");
     const url = std.fmt.bufPrintZ(&url_buffer, "http://127.0.0.1:{d}/", .{port}) catch
         return error.NativeRuntimeUnavailable;
+    const url_string = sendOne(string_class, sel("stringWithUTF8String:"), @ptrCast(url.ptr)) orelse
+        return error.NativeRuntimeUnavailable;
     const url_class = cls("NSURL") orelse return error.NativeRuntimeUnavailable;
-    const ns_url = sendOne(url_class, sel("URLWithString:"), @ptrCast(url.ptr)) orelse
+    const ns_url = sendOne(url_class, sel("URLWithString:"), url_string) orelse
         return error.NativeRuntimeUnavailable;
     const request_class = cls("NSURLRequest") orelse return error.NativeRuntimeUnavailable;
     const request = sendOne(request_class, sel("requestWithURL:"), ns_url) orelse


### PR DESCRIPTION
Supersedes #100 with the first deliberately small native macOS slice.

## What changed
- Added `mer.native.runLoopback`, a minimal public API that presents an already-bound loopback server in the system `NSWindow` + `WKWebView`.
- Reused that API from the existing desktop example, fixed its Zig 0.16 readiness calls, and initialized the framework I/O runtime before the server thread starts.
- Kept the URL internal and loopback-only, validated window inputs, enforced AppKit's main-thread contract, and made closing the final window return from the event loop.
- Added macOS compile/link and bundle validation to release-targeted CI and tagged-release gating.
- Kept every commit below 400 changed lines; the largest is 228 lines. The whole PR is 499 changed lines across 8 files.

## Why
- **Problem/failure mode:** The existing desktop example duplicated all Objective-C host code, no longer compiled against the current `ServerReady` API, and could use the server before `runtime.init`. The previous native proposal grew to hundreds of files and mixed the shell with bridges, updaters, signing, packages, and unrelated framework work.
- **Reason for this approach:** This promotes the already-proven macOS spike into one reusable framework seam while leaving HTTP routing and server behavior unchanged. It is the smallest useful foundation for downstream apps such as Codegraff.
- **Constraints and trade-offs:** Apps still own server startup/shutdown and must link AppKit, WebKit, Foundation, and libc. The repository's example server remains process-lifetime because `Server.listen` has no graceful stop API yet.
- **Rejected alternatives:** This does not salvage or split the old mega-PR. Manifest packaging, JavaScript-to-Zig commands, permissions, signing/notarization, updates, and other platforms are intentionally deferred to separately approved PRs.

## Validation
- `zig build test --summary all` — 25 passed, 2 skipped
- `zig build prod`
- `zig build cli`
- `zig build desktop -Doptimize=ReleaseSmall`
- `plutil -lint zig-out/MerApp.app/Contents/Info.plist`
- targeted `zig fmt --check`
- `git diff --check`
- independent adversarial review loop completed with no actionable findings
